### PR TITLE
Restore option to build GTK2

### DIFF
--- a/toolkit/moz.configure
+++ b/toolkit/moz.configure
@@ -117,8 +117,8 @@ set_config('L10NBASEDIR', l10n_base)
 # `choices` depending on the target, but that doesn't pan out for the same
 # reason.
 option('--enable-default-toolkit', nargs=1,
-       choices=('cairo-windows', 'cairo-gtk3', 'cairo-cocoa', 'cairo-uikit',
-                'cairo-android', 'cairo-gonk'),
+       choices=('cairo-windows', 'cairo-gtk3', 'cairo-gtk2', 'cairo-gtk2-x11',
+                'cairo-cocoa', 'cairo-uikit', 'cairo-android', 'cairo-gonk'),
        help='Select default toolkit')
 
 @depends('--enable-default-toolkit', target)
@@ -140,7 +140,7 @@ def toolkit(value, target):
         else:
             platform_choices = ('cairo-android',)
     else:
-        platform_choices = ('cairo-gtk3',)
+        platform_choices = ('cairo-gtk3', 'cairo-gtk2', 'cairo-gtk2-x11')
 
     if value:
         if value[0] not in platform_choices:


### PR DESCRIPTION
The PR restores the option to build with only GTK2 (using the "--enable-default-toolkit=cairo-gtk2" mozconfig option).

Note that I have not actually compiled or tested a GTK2 build; this PR simply restores the possibility to produce one. Whether or not the build process completes successfully and how stable the resulting build would be must still be evaluated (#27).