### PR TITLE
Build - a custom .mozconfig - fix

### DIFF
--- a/dom/media/webrtc/MediaEngine.h
+++ b/dom/media/webrtc/MediaEngine.h
@@ -226,7 +226,7 @@ public:
     ~AllocationHandle() {}
   public:
     AllocationHandle(const dom::MediaTrackConstraints& aConstraints,
-                     const ipc::PrincipalInfo& aPrincipalInfo,
+                     const mozilla::ipc::PrincipalInfo& aPrincipalInfo,
                      const MediaEnginePrefs& aPrefs,
                      const nsString& aDeviceId)
 
@@ -236,7 +236,7 @@ public:
       mDeviceId(aDeviceId) {}
   public:
     NormalizedConstraints mConstraints;
-    ipc::PrincipalInfo mPrincipalInfo;
+    mozilla::ipc::PrincipalInfo mPrincipalInfo;
     MediaEnginePrefs mPrefs;
     nsString mDeviceId;
   };

--- a/dom/media/webrtc/MediaEngine.h
+++ b/dom/media/webrtc/MediaEngine.h
@@ -327,7 +327,7 @@ public:
   virtual nsresult Allocate(const dom::MediaTrackConstraints &aConstraints,
                             const MediaEnginePrefs &aPrefs,
                             const nsString& aDeviceId,
-                            const ipc::PrincipalInfo& aPrincipalInfo,
+                            const mozilla::ipc::PrincipalInfo& aPrincipalInfo,
                             AllocationHandle** aOutHandle,
                             const char** aOutBadConstraint)
   {


### PR DESCRIPTION
A custom .mozconfig - the compile failed with the following errors:
```
[drive]:\[path]\dist\include\MediaEngine.h(228):
error C2872: 'ipc': ambiguous symbol

[drive]:\[path]\ipc\ipdl\_ipdlheaders\mozilla/ipc/PBackgroundSharedTypes.h(751):
note: could be 'mozilla::ipc'

[drive]:\[path]\dist\include\mozilla/dom/ipc/StructuredCloneData.h(33):
note: or       'mozilla::dom::ipc'

[drive]:\[path]\dist\include\MediaEngine.h(239):
error C2872: 'ipc': ambiguous symbol

[drive]:\[path]\ipc\ipdl\_ipdlheaders\mozilla/ipc/PBackgroundSharedTypes.h(751):
note: could be 'mozilla::ipc'

[drive]:\[path]\dist\include\mozilla/dom/ipc/StructuredCloneData.h(33):
note: or       'mozilla::dom::ipc'

[drive]:\[path]\dist\include\MediaEngine.h(330):
error C2872: 'ipc': ambiguous symbol

[drive]:\[path]\ipc\ipdl\_ipdlheaders\mozilla/ipc/PBackgroundSharedTypes.h(751):
note: could be 'mozilla::ipc'

[drive]:\[path]\dist\include\mozilla/dom/ipc/StructuredCloneData.h(33):
note: or       'mozilla::dom::ipc'
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1335250

---

I've created the new build (x32, Windows).
