### PR TITLE
DevTools - Scratchpad - fix an old bug (Ctrl+Shift+R / Reload and Run)

### DIFF
--- a/devtools/client/scratchpad/scratchpad.xul
+++ b/devtools/client/scratchpad/scratchpad.xul
@@ -121,7 +121,7 @@
   <key id="sp-key-reloadAndRun"
        key="&reloadAndRun.key;"
        command="sp-cmd-reloadAndRun"
-       modifiers="accel,shift"/>
+       modifiers="accel,alt"/>
   <key id="sp-key-evalFunction"
        key="&evalFunction.key;"
        command="sp-cmd-evalFunction"


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/pull/1275

---

I've created the new build (x32, Windows) and tested.
