### PR TITLE
DevTools - Inspector - tooltip get element width/height wrong when browser zoomed

### DIFF
--- a/devtools/client/inspector/test/browser.ini
+++ b/devtools/client/inspector/test/browser.ini
@@ -116,6 +116,7 @@ skip-if = (os == 'linux' && bits == 32 && debug) # bug 1328915, disable linux32 
 [browser_inspector_infobar_01.js]
 [browser_inspector_infobar_02.js]
 [browser_inspector_infobar_03.js]
+[browser_inspector_infobar_04.js]
 [browser_inspector_infobar_textnode.js]
 [browser_inspector_initialization.js]
 skip-if = (e10s && debug) # Bug 1250058 - Docshell leak on debug e10s

--- a/devtools/client/inspector/test/browser_inspector_infobar_04.js
+++ b/devtools/client/inspector/test/browser_inspector_infobar_04.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// Check the position and text content of the highlighter nodeinfo bar under page zoom.
+
+const TEST_URI = URL_ROOT + "doc_inspector_infobar_01.html";
+
+add_task(function* () {
+  let {inspector, testActor} = yield openInspectorForURL(TEST_URI);
+  let testData = {
+    selector: "#top",
+    dims: "500" + " \u00D7 " + "100"
+  };
+
+  yield testInfobar(testData, inspector, testActor);
+  info("Change zoom page to level 2.");
+  yield testActor.zoomPageTo(2);
+  info("Testing again the infobar after zoom.");
+  yield testInfobar(testData, inspector, testActor);
+});
+
+function* testInfobar(test, inspector, testActor) {
+  info(`Testing ${test.selector}`);
+
+  yield selectAndHighlightNode(test.selector, inspector);
+
+  // Ensure the node is the correct one.
+  let id = yield testActor.getHighlighterNodeTextContent(
+    "box-model-infobar-id");
+  is(id, test.selector, `Node ${test.selector} selected.`);
+
+  let dims = yield testActor.getHighlighterNodeTextContent(
+    "box-model-infobar-dimensions");
+  is(dims, test.dims, "Node's infobar displays the right dimensions.");
+}

--- a/devtools/server/actors/highlighters/box-model.js
+++ b/devtools/server/actors/highlighters/box-model.js
@@ -15,7 +15,10 @@ const {
   isNodeValid,
   moveInfobar,
 } = require("./utils/markup");
-const { setIgnoreLayoutChanges } = require("devtools/shared/layout/utils");
+const {
+  setIgnoreLayoutChanges,
+  getCurrentZoom,
+ } = require("devtools/shared/layout/utils");
 const inspector = require("devtools/server/actors/inspector");
 const nodeConstants = require("devtools/shared/dom-node-constants");
 
@@ -670,10 +673,14 @@ BoxModelHighlighter.prototype = extend(AutoRefreshHighlighter.prototype, {
       pseudos += ":" + pseudo;
     }
 
-    let rect = this._getOuterQuad("border").bounds;
-    let dim = parseFloat(rect.width.toPrecision(6)) +
+    // We want to display the original `width` and `height`, instead of the ones affected
+    // by any zoom. Since the infobar can be displayed also for text nodes, we can't
+    // access the computed style for that, and this is why we recalculate them here.
+    let zoom = getCurrentZoom(this.win);
+    let { width, height } = this._getOuterQuad("border").bounds;
+    let dim = parseFloat((width / zoom).toPrecision(6)) +
               " \u00D7 " +
-              parseFloat(rect.height.toPrecision(6));
+              parseFloat((height / zoom).toPrecision(6));
 
     this.getElement("infobar-tagname").setTextContent(displayName);
     this.getElement("infobar-id").setTextContent(id);


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/pull/1160
(https://bugzilla.mozilla.org/show_bug.cgi?id=1341580)

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
