### PR TITLE
[partial fix] DevTools - network - proxy - throws an errors (remoteAddress)

### DIFF
--- a/devtools/shared/webconsole/network-monitor.js
+++ b/devtools/shared/webconsole/network-monitor.js
@@ -1342,8 +1342,24 @@ NetworkMonitor.prototype = {
 
     let response = {};
     response.httpVersion = statusLineArray.shift();
-    response.remoteAddress = httpActivity.channel.remoteAddress;
-    response.remotePort = httpActivity.channel.remotePort;
+    // XXX: 
+    // Sometimes, when using a proxy server (manual proxy configuration),
+    // throws an errors:
+    // 0x80040111 (NS_ERROR_NOT_AVAILABLE)
+    // [nsIHttpChannelInternal.remoteAddress]
+    // Bug 1337791 is the suspect.
+    response.remoteAddress = null;
+    try {
+      response.remoteAddress = httpActivity.channel.remoteAddress;
+    } catch (e) {
+      Cu.reportError(e);
+    }
+    response.remotePort = null;
+    try {
+      response.remotePort = httpActivity.channel.remotePort;
+    } catch (e) {
+      Cu.reportError(e);
+    }
     response.status = statusLineArray.shift();
     response.statusText = statusLineArray.join(" ");
     response.headersSize = extraStringData.length;


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/pull/1252

An example:
https://blog.cloudflare.com/introducing-tls-1-3/

Throws an error in Browser Console:
```
"Handler function threw an exception:
[Exception... "Component returned failure code: 0x80040111 (NS_ERROR_NOT_AVAILABLE)
[nsIHttpChannelInternal.remoteAddress]"
nsresult: "0x80040111 (NS_ERROR_NOT_AVAILABLE)"
location: "JS frame ::
resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/webconsole/network-monitor.js
:: _onResponseHeader :: line 1345" data: no]
Stack:
_onResponseHeader@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/webconsole/network-monitor.js:1345:5
_dispatchActivity@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/webconsole/network-monitor.js:981:9
NetworkMonitor.prototype.observeActivity
<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/webconsole/network-monitor.js:1043:7
exports.makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/ThreadSafeDevToolsUtils.js:101:14
Line: 1345, column: 0"
```

Pushlog:
https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?fromchange=b6cbd404c8453d0f726eaab50eceeba22d859554&tochange=8b7e27246485369587088ec572f59f397c4bff72

[Bug 1337791](https://bugzilla.mozilla.org/show_bug.cgi?id=1337791) is the suspect.

See also:
https://github.com/MoonchildProductions/Pale-Moon/issues/1057#issuecomment-297498332

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested ("this error must not be critical").
