### PR TITLE
[minor fix] about:... - throws an errors

### DIFF
--- a/browser/base/content/sync/aboutSyncTabs.js
+++ b/browser/base/content/sync/aboutSyncTabs.js
@@ -183,7 +183,8 @@ var RemoteTabViewer = {
       }
     }
 
-    if (CloudSync && CloudSync.ready && CloudSync().tabsReady && CloudSync().tabs.hasRemoteTabs()) {
+    if (AppConstants.MOZ_SERVICES_CLOUDSYNC && CloudSync && CloudSync.ready &&
+        CloudSync().tabsReady && CloudSync().tabs.hasRemoteTabs()) {
       this._generateCloudSyncTabList()
           .then(complete, complete);
     } else {

--- a/toolkit/components/aboutcache/content/aboutCache.js
+++ b/toolkit/components/aboutcache/content/aboutCache.js
@@ -39,5 +39,9 @@ function navigate() {
   if ($("priv").checked)
     context += "p,";
 
+  if (storage == null) {
+    storage = "";
+  }
+
   window.location.href = "about:cache?storage=" + storage + "&context=" + context;
 }

--- a/toolkit/modules/sessionstore/FormData.jsm
+++ b/toolkit/modules/sessionstore/FormData.jsm
@@ -216,7 +216,7 @@ var FormDataInternal = {
     // We want to avoid saving data for about:sessionrestore as a string.
     // Since it's stored in the form as stringified JSON, stringifying further
     // causes an explosion of escape characters. cf. bug 467409
-    if (isRestorationPage(ret.url)) {
+    if (isRestorationPage(ret.url) && ret.id && ret.id.sessionData) {
       ret.id.sessionData = JSON.parse(ret.id.sessionData);
     }
 


### PR DESCRIPTION
---

## 1) `about:`

---

Throws an error in Browser Console:
```
formatURLPref: Couldn't get pref: app.releaseNotesURL
nsURLFormatter.js:143
formatURLPref: Couldn't get pref: app.vendorURL
nsURLFormatter.js:143
```

`app.releaseNotesURL` - see:
https://bugzilla.mozilla.org/show_bug.cgi?id=1367145

---

## 2) `about:cache`

---

Throws an error:
![aboutcache](https://user-images.githubusercontent.com/2373486/29271385-68ab1756-80fb-11e7-9689-b4223cb9916e.png)


---

See also:
https://github.com/MoonchildProductions/Pale-Moon/commit/25752a3bc20c3b436d8c2fb85082b27540c3833f

---

## 3) `about:sync-tabs`

---

Throws an error in Browser Console:
```
ReferenceError: CloudSync is not defined
aboutSyncTabs.js:186:1
```

---

## 4) `about:welcomeback`

---

`(*) Restore only the ones you want`

Throws an error in Browser Console:
```
TypeError: gStateObject is undefined
aboutSessionRestore.js:71:3
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
FormData.jsm:220:28
```

---

I've created the new build (x32, Windows) and tested.
