### PR TITLE
[minor fix] DevTools - css - css-color-4 - fix typo

### DIFF
--- a/devtools/server/actors/css-properties.js
+++ b/devtools/server/actors/css-properties.js
@@ -32,7 +32,7 @@ exports.CssPropertiesActor = ActorClassWithSpec(cssPropertiesSpec, {
     const pseudoElements = DOMUtils.getCSSPseudoElementNames();
     const supportedFeature = {
       // checking for css-color-4 color function support.
-      "css-color-4-color-function": DOMUtils.isValidCSSColor("rgb(1 1 1 / 100%"),
+      "css-color-4-color-function": DOMUtils.isValidCSSColor("rgb(1 1 1 / 100%)"),
     };
 
     return { properties, pseudoElements, supportedFeature };


### PR DESCRIPTION
See:
https://hg.mozilla.org/mozilla-central/rev/1697080a4726

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows).
