### PR TITLE
DevTools - network - improvements (transferred size, DOMContentLoaded and load)

### DIFF
--- a/devtools/client/locales/en-US/netmonitor.properties
+++ b/devtools/client/locales/en-US/netmonitor.properties
@@ -147,12 +147,12 @@ networkMenu.sortedDesc=Sorted descending
 # in the network table footer when there are no requests available.
 networkMenu.empty=No requests
 
-# LOCALIZATION NOTE (networkMenu.summary): Semi-colon list of plural forms.
+# LOCALIZATION NOTE (networkMenu.summary2): Semi-colon list of plural forms.
 # See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
 # This label is displayed in the network table footer providing concise
 # information about all requests. Parameters: #1 is the number of requests,
-# #2 is the size, #3 is the number of seconds.
-networkMenu.summary=One request, #2 KB, #3 s;#1 requests, #2 KB, #3 s
+# #2 is the size, #3 is the transferred size, #4 is the number of seconds.
+networkMenu.summary2=One request, #2 KB (transferred: #3 KB), #4 s;#1 requests, #2 KB (transferred: #3 KB), #4 s
 
 # LOCALIZATION NOTE (networkMenu.sizeB): This is the label displayed
 # in the network menu specifying the size of a request (in bytes).

--- a/devtools/client/locales/en-US/netmonitor.properties
+++ b/devtools/client/locales/en-US/netmonitor.properties
@@ -154,6 +154,11 @@ networkMenu.empty=No requests
 # #2 is the size, #3 is the transferred size, #4 is the number of seconds.
 networkMenu.summary2=One request, #2 KB (transferred: #3 KB), #4 s;#1 requests, #2 KB (transferred: #3 KB), #4 s
 
+# LOCALIZATION NOTE (networkMenu.timeS): This is the label displayed
+# in the network table footer providing concise information about all requests.
+# Events DOMContentLoaded and load - specifying the number of seconds.
+networkMenu.timeS=%S s
+
 # LOCALIZATION NOTE (networkMenu.sizeB): This is the label displayed
 # in the network menu specifying the size of a request (in bytes).
 networkMenu.sizeB=%S B
@@ -225,9 +230,17 @@ tableChart.unavailable=No data available
 # in pie or table charts specifying the size of a request (in kilobytes).
 charts.sizeKB=%S KB
 
+# LOCALIZATION NOTE (charts.transferredSizeKB): This is the label displayed
+# in pie or table charts specifying the size of a transferred request (in kilobytes).
+charts.transferredSizeKB=%S KB
+
 # LOCALIZATION NOTE (charts.totalS): This is the label displayed
 # in pie or table charts specifying the time for a request to finish (in seconds).
 charts.totalS=%S s
+
+# LOCALIZATION NOTE (charts.totalTranferredSize): This is the label displayed
+# in the performance analysis view for total transferred size, in kilobytes.
+charts.totalTransferredSize=Transferred Size: %S KB
 
 # LOCALIZATION NOTE (charts.cacheEnabled): This is the label displayed
 # in the performance analysis view for "cache enabled" charts.
@@ -254,6 +267,23 @@ charts.totalCached=Cached responses: %S
 # LOCALIZATION NOTE (charts.totalCount): This is the label displayed
 # in the performance analysis view for total requests.
 charts.totalCount=Total requests: %S
+
+# LOCALIZATION NOTE (charts.totalCount): This is the label displayed
+# in the header column in the performance analysis view for size of the request.
+charts.size=Size
+
+# LOCALIZATION NOTE (charts.totalCount): This is the label displayed
+# in the header column in the performance analysis view for type of request.
+charts.type=Type
+
+# LOCALIZATION NOTE (charts.totalCount): This is the label displayed
+# in the header column in the performance analysis view for transferred
+# size of the request.
+charts.transferred=Transferred
+
+# LOCALIZATION NOTE (charts.totalCount): This is the label displayed
+# in the header column in the performance analysis view for time of request.
+charts.time=Time
 
 # LOCALIZATION NOTE (netRequest.headers): A label used for Headers tab
 # This tab displays list of HTTP headers

--- a/devtools/client/netmonitor/components/summary-button.js
+++ b/devtools/client/netmonitor/components/summary-button.js
@@ -21,12 +21,13 @@ function SummaryButton({
   summary,
   triggerSummary,
 }) {
-  let { count, bytes, millis } = summary;
+  let { count, contentSize, transferredSize, millis } = summary;
   const text = (count === 0) ? L10N.getStr("networkMenu.empty") :
-    PluralForm.get(count, L10N.getStr("networkMenu.summary"))
+    PluralForm.get(count, L10N.getStr("networkMenu.summary2"))
     .replace("#1", count)
-    .replace("#2", getSizeWithDecimals(bytes / 1024))
-    .replace("#3", getTimeWithDecimals(millis / 1000));
+    .replace("#2", getSizeWithDecimals(contentSize / 1024))
+    .replace("#3", getSizeWithDecimals(transferredSize / 1024))
+    .replace("#4", getTimeWithDecimals(millis / 1000));
 
   return button({
     id: "requests-menu-network-summary-button",

--- a/devtools/client/netmonitor/components/summary-button.js
+++ b/devtools/client/netmonitor/components/summary-button.js
@@ -8,7 +8,10 @@ const { DOM, PropTypes } = require("devtools/client/shared/vendor/react");
 const { connect } = require("devtools/client/shared/vendor/react-redux");
 const { PluralForm } = require("devtools/shared/plural-form");
 const { L10N } = require("../l10n");
-const { getDisplayedRequestsSummary } = require("../selectors/index");
+const {
+  getDisplayedRequestsSummary,
+  getDisplayedTimingMarker
+} = require("../selectors/index");
 const Actions = require("../actions/index");
 const {
   getSizeWithDecimals,
@@ -20,14 +23,25 @@ const { button, span } = DOM;
 function SummaryButton({
   summary,
   triggerSummary,
+  timingMarkers
 }) {
   let { count, contentSize, transferredSize, millis } = summary;
+  let {
+    DOMContentLoaded,
+    load,
+  } = timingMarkers;
   const text = (count === 0) ? L10N.getStr("networkMenu.empty") :
     PluralForm.get(count, L10N.getStr("networkMenu.summary2"))
     .replace("#1", count)
     .replace("#2", getSizeWithDecimals(contentSize / 1024))
     .replace("#3", getSizeWithDecimals(transferredSize / 1024))
-    .replace("#4", getTimeWithDecimals(millis / 1000));
+    .replace("#4", getTimeWithDecimals(millis / 1000))
+    + ((DOMContentLoaded > -1)
+        ? ", " + "DOMContentLoaded: " + L10N.getFormatStrWithNumbers("networkMenu.timeS", getTimeWithDecimals(DOMContentLoaded / 1000))
+        : "")
+    + ((load > -1)
+        ? ", " + "load: " + L10N.getFormatStrWithNumbers("networkMenu.timeS", getTimeWithDecimals(load / 1000))
+        : "");
 
   return button({
     id: "requests-menu-network-summary-button",
@@ -41,11 +55,17 @@ function SummaryButton({
 
 SummaryButton.propTypes = {
   summary: PropTypes.object.isRequired,
+  timingMarkers: PropTypes.object.isRequired,
 };
 
 module.exports = connect(
   (state) => ({
     summary: getDisplayedRequestsSummary(state),
+    timingMarkers: {
+      DOMContentLoaded:
+        getDisplayedTimingMarker(state, "firstDocumentDOMContentLoadedTimestamp"),
+      load: getDisplayedTimingMarker(state, "firstDocumentLoadTimestamp"),
+    },
   }),
   (dispatch) => ({
     triggerSummary: () => {

--- a/devtools/client/netmonitor/selectors/index.js
+++ b/devtools/client/netmonitor/selectors/index.js
@@ -6,10 +6,12 @@
 
 const filters = require("./filters");
 const requests = require("./requests");
+const timingMarkers = require("./timing-markers");
 const ui = require("./ui");
 
 Object.assign(exports,
   filters,
   requests,
+  timingMarkers,
   ui
 );

--- a/devtools/client/netmonitor/selectors/moz.build
+++ b/devtools/client/netmonitor/selectors/moz.build
@@ -6,5 +6,6 @@ DevToolsModules(
     'filters.js',
     'index.js',
     'requests.js',
+    'timing-markers.js',
     'ui.js',
 )

--- a/devtools/client/netmonitor/selectors/requests.js
+++ b/devtools/client/netmonitor/selectors/requests.js
@@ -77,16 +77,22 @@ const getDisplayedRequestsSummary = createSelector(
       return { count: 0, bytes: 0, millis: 0 };
     }
 
-    const totalBytes = requests.reduce((total, item) => {
+    const totalBytes = requests.reduce((totals, item) => {
       if (typeof item.contentSize == "number") {
-        total += item.contentSize;
+        totals.contentSize += item.contentSize;
       }
-      return total;
-    }, 0);
+
+      if (typeof item.transferredSize == "number") {
+        totals.transferredSize += item.transferredSize;
+      }
+
+      return totals;
+    }, { contentSize: 0, transferredSize: 0 });
 
     return {
       count: requests.size,
-      bytes: totalBytes,
+      contentSize: totalBytes.contentSize,
+      transferredSize: totalBytes.transferredSize,
       millis: totalMillis,
     };
   }

--- a/devtools/client/netmonitor/selectors/timing-markers.js
+++ b/devtools/client/netmonitor/selectors/timing-markers.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+function getDisplayedTimingMarker(state, marker) {
+  return state.timingMarkers.get(marker) - state.requests.get("firstStartedMillis");
+}
+
+module.exports = {
+  getDisplayedTimingMarker,
+};

--- a/devtools/client/netmonitor/statistics-view.js
+++ b/devtools/client/netmonitor/statistics-view.js
@@ -118,27 +118,35 @@ StatisticsView.prototype = {
       let string = getSizeWithDecimals(value / 1024);
       return L10N.getFormatStr("charts.sizeKB", string);
     },
+    transferredSize: value => {
+      let string = getSizeWithDecimals(value / 1024);
+      return L10N.getFormatStr("charts.transferredSizeKB", string);
+    },
     time: value => {
       let string = getTimeWithDecimals(value / 1000);
       return L10N.getFormatStr("charts.totalS", string);
     }
   },
   _commonChartTotals: {
+    cached: total => {
+      return L10N.getFormatStr("charts.totalCached", total);
+    },
+    count: total => {
+      return L10N.getFormatStr("charts.totalCount", total);
+    },
     size: total => {
       let string = getSizeWithDecimals(total / 1024);
       return L10N.getFormatStr("charts.totalSize", string);
+    },
+    transferredSize: total => {
+      let string = getSizeWithDecimals(total / 1024);
+      return L10N.getFormatStr("charts.totalTransferredSize", string);
     },
     time: total => {
       let seconds = total / 1000;
       let string = getTimeWithDecimals(seconds);
       return PluralForm.get(seconds,
         L10N.getStr("charts.totalSeconds")).replace("#1", string);
-    },
-    cached: total => {
-      return L10N.getFormatStr("charts.totalCached", total);
-    },
-    count: total => {
-      return L10N.getFormatStr("charts.totalCount", total);
     }
   },
 
@@ -162,6 +170,14 @@ StatisticsView.prototype = {
     let chart = this.Chart.PieTable(document, {
       diameter: NETWORK_ANALYSIS_PIE_CHART_DIAMETER,
       title: L10N.getStr(title),
+      header: {
+        cached: "",
+        count: "",
+        label: L10N.getStr("charts.type"),
+        size: L10N.getStr("charts.size"),
+        transferredSize: L10N.getStr("charts.transferred"),
+        time: L10N.getStr("charts.time")
+      },
       data: data,
       strings: strings,
       totals: totals,
@@ -187,13 +203,14 @@ StatisticsView.prototype = {
    *        True if the cache is considered enabled, false for disabled.
    */
   _sanitizeChartDataSource: function (items, emptyCache) {
-    let data = [
+    const data = [
       "html", "css", "js", "xhr", "fonts", "images", "media", "flash", "ws", "other"
     ].map(e => ({
       cached: 0,
       count: 0,
       label: e,
       size: 0,
+      transferredSize: 0,
       time: 0
     }));
 
@@ -237,6 +254,7 @@ StatisticsView.prototype = {
       if (emptyCache || !responseIsFresh(details)) {
         data[type].time += details.totalTime || 0;
         data[type].size += details.contentSize || 0;
+        data[type].transferredSize += details.transferredSize || 0;
       } else {
         data[type].cached++;
       }

--- a/devtools/client/netmonitor/test/browser_net_charts-03.js
+++ b/devtools/client/netmonitor/test/browser_net_charts-03.js
@@ -34,6 +34,10 @@ add_task(function* () {
     totals: {
       label1: value => "Hello " + L10N.numberWithDecimals(value, 2),
       label2: value => "World " + L10N.numberWithDecimals(value, 2)
+    },
+    header: {
+      label1: "label1header",
+      label2: "label2header",
     }
   });
 
@@ -52,39 +56,48 @@ add_task(function* () {
   is(title.textContent, "Table title",
     "The title node displays the correct text.");
 
-  is(rows.length, 3, "There should be 3 table chart rows created.");
+  is(rows.length, 4, "There should be 3 table chart rows and a header created.");
 
-  ok(rows[0].querySelector(".table-chart-row-box.chart-colored-blob"),
-    "A colored blob exists for the firt row.");
   is(rows[0].querySelectorAll("span")[0].getAttribute("name"), "label1",
-    "The first column of the first row exists.");
+    "The first column of the header exists.");
   is(rows[0].querySelectorAll("span")[1].getAttribute("name"), "label2",
-    "The second column of the first row exists.");
-  is(rows[0].querySelectorAll("span")[0].textContent, "1",
-    "The first column of the first row displays the correct text.");
-  is(rows[0].querySelectorAll("span")[1].textContent, "11.1foo",
-    "The second column of the first row displays the correct text.");
+    "The second column of the header exists.");
+  is(rows[0].querySelectorAll("span")[0].textContent, "label1header",
+    "The first column of the header displays the correct text.");
+  is(rows[0].querySelectorAll("span")[1].textContent, "label2header",
+    "The second column of the header displays the correct text.");
 
   ok(rows[1].querySelector(".table-chart-row-box.chart-colored-blob"),
-    "A colored blob exists for the second row.");
+    "A colored blob exists for the firt row.");
   is(rows[1].querySelectorAll("span")[0].getAttribute("name"), "label1",
-    "The first column of the second row exists.");
+    "The first column of the first row exists.");
   is(rows[1].querySelectorAll("span")[1].getAttribute("name"), "label2",
-    "The second column of the second row exists.");
-  is(rows[1].querySelectorAll("span")[0].textContent, "2",
-    "The first column of the second row displays the correct text.");
-  is(rows[1].querySelectorAll("span")[1].textContent, "12.2bar",
+    "The second column of the first row exists.");
+  is(rows[1].querySelectorAll("span")[0].textContent, "1",
+    "The first column of the first row displays the correct text.");
+  is(rows[1].querySelectorAll("span")[1].textContent, "11.1foo",
     "The second column of the first row displays the correct text.");
 
   ok(rows[2].querySelector(".table-chart-row-box.chart-colored-blob"),
-    "A colored blob exists for the third row.");
+    "A colored blob exists for the second row.");
   is(rows[2].querySelectorAll("span")[0].getAttribute("name"), "label1",
-    "The first column of the third row exists.");
+    "The first column of the second row exists.");
   is(rows[2].querySelectorAll("span")[1].getAttribute("name"), "label2",
+    "The second column of the second row exists.");
+  is(rows[2].querySelectorAll("span")[0].textContent, "2",
+    "The first column of the second row displays the correct text.");
+  is(rows[2].querySelectorAll("span")[1].textContent, "12.2bar",
+    "The second column of the first row displays the correct text.");
+
+  ok(rows[3].querySelector(".table-chart-row-box.chart-colored-blob"),
+    "A colored blob exists for the third row.");
+  is(rows[3].querySelectorAll("span")[0].getAttribute("name"), "label1",
+    "The first column of the third row exists.");
+  is(rows[3].querySelectorAll("span")[1].getAttribute("name"), "label2",
     "The second column of the third row exists.");
-  is(rows[2].querySelectorAll("span")[0].textContent, "3",
+  is(rows[3].querySelectorAll("span")[0].textContent, "3",
     "The first column of the third row displays the correct text.");
-  is(rows[2].querySelectorAll("span")[1].textContent, "13.3baz",
+  is(rows[3].querySelectorAll("span")[1].textContent, "13.3baz",
     "The second column of the third row displays the correct text.");
 
   is(sums.length, 2, "There should be 2 total summaries created.");

--- a/devtools/client/netmonitor/test/browser_net_charts-04.js
+++ b/devtools/client/netmonitor/test/browser_net_charts-04.js
@@ -23,6 +23,10 @@ add_task(function* () {
     totals: {
       label1: value => "Hello " + L10N.numberWithDecimals(value, 2),
       label2: value => "World " + L10N.numberWithDecimals(value, 2)
+    },
+    header: {
+      label1: "",
+      label2: ""
     }
   });
 
@@ -41,17 +45,17 @@ add_task(function* () {
   is(title.textContent, "Table title",
     "The title node displays the correct text.");
 
-  is(rows.length, 1, "There should be 1 table chart row created.");
+  is(rows.length, 2, "There should be 1 table chart row and a 1 header created.");
 
-  ok(rows[0].querySelector(".table-chart-row-box.chart-colored-blob"),
+  ok(rows[1].querySelector(".table-chart-row-box.chart-colored-blob"),
     "A colored blob exists for the firt row.");
-  is(rows[0].querySelectorAll("span")[0].getAttribute("name"), "size",
+  is(rows[1].querySelectorAll("span")[0].getAttribute("name"), "size",
     "The first column of the first row exists.");
-  is(rows[0].querySelectorAll("span")[1].getAttribute("name"), "label",
+  is(rows[1].querySelectorAll("span")[1].getAttribute("name"), "label",
     "The second column of the first row exists.");
-  is(rows[0].querySelectorAll("span")[0].textContent, "",
+  is(rows[1].querySelectorAll("span")[0].textContent, "",
     "The first column of the first row displays the correct text.");
-  is(rows[0].querySelectorAll("span")[1].textContent,
+  is(rows[1].querySelectorAll("span")[1].textContent,
     L10N.getStr("tableChart.loading"),
     "The second column of the first row displays the correct text.");
 

--- a/devtools/client/netmonitor/test/browser_net_charts-05.js
+++ b/devtools/client/netmonitor/test/browser_net_charts-05.js
@@ -34,6 +34,10 @@ add_task(function* () {
     totals: {
       size: value => "Hello " + L10N.numberWithDecimals(value, 2),
       label: value => "World " + L10N.numberWithDecimals(value, 2)
+    },
+    header: {
+      label1: "",
+      label2: ""
     }
   });
 
@@ -54,9 +58,9 @@ add_task(function* () {
   ok(node.querySelector(".table-chart-container"),
     "A table chart was created successfully.");
 
-  is(rows.length, 3, "There should be 3 pie chart slices created.");
-  is(rows.length, 3, "There should be 3 table chart rows created.");
-  is(sums.length, 2, "There should be 2 total summaries created.");
+  is(rows.length, 4, "There should be 3 pie chart slices and 1 header created.");
+  is(rows.length, 4, "There should be 3 table chart rows and 1 header created.");
+  is(sums.length, 2, "There should be 2 total summaries and 1 header created.");
 
   yield teardown(monitor);
 });

--- a/devtools/client/netmonitor/test/browser_net_charts-07.js
+++ b/devtools/client/netmonitor/test/browser_net_charts-07.js
@@ -21,6 +21,10 @@ add_task(function* () {
     totals: {
       label1: value => "Hello " + L10N.numberWithDecimals(value, 2),
       label2: value => "World " + L10N.numberWithDecimals(value, 2)
+    },
+    header: {
+      label1: "",
+      label2: ""
     }
   });
 
@@ -30,17 +34,17 @@ add_task(function* () {
   let rows = grid.querySelectorAll(".table-chart-row");
   let sums = node.querySelectorAll(".table-chart-summary-label");
 
-  is(rows.length, 1, "There should be 1 table chart row created.");
+  is(rows.length, 2, "There should be 1 table chart row and 1 header created.");
 
-  ok(rows[0].querySelector(".table-chart-row-box.chart-colored-blob"),
+  ok(rows[1].querySelector(".table-chart-row-box.chart-colored-blob"),
     "A colored blob exists for the firt row.");
-  is(rows[0].querySelectorAll("span")[0].getAttribute("name"), "size",
+  is(rows[1].querySelectorAll("span")[0].getAttribute("name"), "size",
     "The first column of the first row exists.");
-  is(rows[0].querySelectorAll("span")[1].getAttribute("name"), "label",
+  is(rows[1].querySelectorAll("span")[1].getAttribute("name"), "label",
     "The second column of the first row exists.");
-  is(rows[0].querySelectorAll("span")[0].textContent, "",
+  is(rows[1].querySelectorAll("span")[0].textContent, "",
     "The first column of the first row displays the correct text.");
-  is(rows[0].querySelectorAll("span")[1].textContent,
+  is(rows[1].querySelectorAll("span")[1].textContent,
     L10N.getStr("tableChart.unavailable"),
     "The second column of the first row displays the correct text.");
 

--- a/devtools/client/netmonitor/test/browser_net_footer-summary.js
+++ b/devtools/client/netmonitor/test/browser_net_footer-summary.js
@@ -62,10 +62,11 @@ add_task(function* () {
     info(`Computed total bytes: ${requestsSummary.bytes}`);
     info(`Computed total millis: ${requestsSummary.millis}`);
 
-    is(value, PluralForm.get(requestsSummary.count, L10N.getStr("networkMenu.summary"))
+    is(value, PluralForm.get(requestsSummary.count, L10N.getStr("networkMenu.summary2"))
       .replace("#1", requestsSummary.count)
-      .replace("#2", L10N.numberWithDecimals(requestsSummary.bytes / 1024, 2))
-      .replace("#3", L10N.numberWithDecimals(requestsSummary.millis / 1000, 2))
+      .replace("#2", L10N.numberWithDecimals(requestsSummary.contentSize / 1024, 2))
+      .replace("#3", L10N.numberWithDecimals(requestsSummary.transferredSize / 1024, 2))
+      .replace("#4", L10N.numberWithDecimals(requestsSummary.millis / 1000, 2))
     , "The current summary text is correct.");
   }
 });

--- a/devtools/client/shared/widgets/Chart.js
+++ b/devtools/client/shared/widgets/Chart.js
@@ -94,7 +94,7 @@ function PieTableChart(node, pie, table) {
  *           - "click", when the mouse enters a slice or a row
  */
 function createPieTableChart(document,
-                             { title, diameter, data, strings, totals, sorted }) {
+                             { title, diameter, data, strings, totals, sorted, header }) {
   if (data && sorted) {
     data = data.slice().sort((a, b) => +(a.size < b.size));
   }
@@ -108,7 +108,8 @@ function createPieTableChart(document,
     title: title,
     data: data,
     strings: strings,
-    totals: totals
+    totals: totals,
+    header: header,
   });
 
   let container = document.createElement("div");
@@ -327,7 +328,7 @@ function createPieChart(document, { data, width, height, centerX, centerY, radiu
  *           - "mouseout", when the mouse leaves a row
  *           - "click", when the mouse clicks a row
  */
-function createTableChart(document, { title, data, strings, totals }) {
+function createTableChart(document, { title, data, strings, totals, header }) {
   strings = strings || {};
   totals = totals || {};
   let isPlaceholder = false;
@@ -361,6 +362,24 @@ function createTableChart(document, { title, data, strings, totals }) {
   tableNode.className = "plain table-chart-grid";
   tableNode.setAttribute("style", "-moz-box-orient: vertical");
   container.appendChild(tableNode);
+
+  const headerNode = document.createElement("div");
+  headerNode.className = "table-chart-row";
+
+  const headerBoxNode = document.createElement("div");
+  headerBoxNode.className = "table-chart-row-box";
+  headerNode.appendChild(headerBoxNode);
+
+  for (let [key, value] of Object.entries(header)) {
+    let headerLabelNode = document.createElement("span");
+    headerLabelNode.className = "plain table-chart-row-label";
+    headerLabelNode.setAttribute("name", key);
+    headerLabelNode.textContent = value;
+
+    headerNode.appendChild(headerLabelNode);
+  }
+
+  tableNode.appendChild(headerNode);
 
   for (let rowInfo of data) {
     let rowNode = document.createElement("div");


### PR DESCRIPTION
- Show transferred size in request summary instead of decompressed size
- Show DOMContentLoaded and load marker times

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1168376
https://bugzilla.mozilla.org/show_bug.cgi?id=1350228 (partially)

Before / After:
![_003_basilisk_001_old](https://user-images.githubusercontent.com/2373486/29581795-c0189736-877a-11e7-8bd2-d62eaa1d4afd.png)
![_003_basilisk_001_new](https://user-images.githubusercontent.com/2373486/29581816-d49cd820-877a-11e7-97c7-67e693b65c75.png)

![_003_basilisk_002_old](https://user-images.githubusercontent.com/2373486/29581798-c4bcb510-877a-11e7-9bae-5e1b99284b6e.png)
![_003_basilisk_002_new](https://user-images.githubusercontent.com/2373486/29581824-d845f8f8-877a-11e7-9c2f-37313a49d199.png)

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
