### PR TITLE
DevTools - inspector - data URL source links and their tooltips are unreadable

### DIFF
--- a/devtools/client/inspector/rules/models/rule.js
+++ b/devtools/client/inspector/rules/models/rule.js
@@ -140,11 +140,18 @@ Rule.prototype = {
                                                      line, mediaText}) => {
       let mediaString = mediaText ? " @" + mediaText : "";
       let linePart = line > 0 ? (":" + line) : "";
+      let decodedHref = href;
+
+      if (decodedHref) {
+        try {
+          decodedHref = decodeURIComponent(href);
+        } catch (e) {}
+      }
 
       let sourceStrings = {
-        full: (href || CssLogic.l10n("rule.sourceInline")) + linePart +
+        full: (decodedHref || CssLogic.l10n("rule.sourceInline")) + linePart +
           mediaString,
-        short: CssLogic.shortSource({href: href}) + linePart + mediaString
+        short: CssLogic.shortSource({href: decodedHref}) + linePart + mediaString
       };
 
       return sourceStrings;

--- a/devtools/client/inspector/rules/test/browser_rules_style-editor-link.js
+++ b/devtools/client/inspector/rules/test/browser_rules_style-editor-link.js
@@ -10,10 +10,12 @@ thisTestLeaksUncaughtRejectionsAndShouldBeFixed("Error: Unknown sheet source");
 
 // Test the links from the rule-view to the styleeditor
 
-const STYLESHEET_URL = "data:text/css," + encodeURIComponent(
-  ["#first {",
-   "color: blue",
-   "}"].join("\n"));
+const STYLESHEET_DATA_URL_CONTENTS = ["#first {",
+                                      "color: blue",
+                                      "}"].join("\n");
+const STYLESHEET_DATA_URL =
+      `data:text/css,${encodeURIComponent(STYLESHEET_DATA_URL_CONTENTS)}`;
+const STYLESHEET_DECODED_DATA_URL = `data:text/css,${STYLESHEET_DATA_URL_CONTENTS}`;
 
 const EXTERNAL_STYLESHEET_FILE_NAME = "doc_style_editor_link.css";
 const EXTERNAL_STYLESHEET_URL = URL_ROOT + EXTERNAL_STYLESHEET_FILE_NAME;
@@ -31,7 +33,7 @@ const DOCUMENT_URL = "data:text/html;charset=utf-8," + encodeURIComponent(`
   <style>
   div { font-weight: bold; }
   </style>
-  <link rel="stylesheet" type="text/css" href="${STYLESHEET_URL}">
+  <link rel="stylesheet" type="text/css" href="${STYLESHEET_DATA_URL}">
   <link rel="stylesheet" type="text/css" href="${EXTERNAL_STYLESHEET_URL}">
   </head>
   <body>
@@ -178,15 +180,28 @@ function* testDisabledStyleEditor(view, toolbox) {
 }
 
 function testRuleViewLinkLabel(view) {
-  let link = getRuleViewLinkByIndex(view, 2);
+  info("Checking the data URL link label");
+
+  let link = getRuleViewLinkByIndex(view, 1);
   let labelElem = link.querySelector(".ruleview-rule-source-label");
   let value = labelElem.textContent;
   let tooltipText = labelElem.getAttribute("title");
 
-  is(value, EXTERNAL_STYLESHEET_FILE_NAME + ":1",
-    "rule view stylesheet display value matches filename and line number");
-  is(tooltipText, EXTERNAL_STYLESHEET_URL + ":1",
-    "rule view stylesheet tooltip text matches the full URI path");
+  is(value, `${STYLESHEET_DATA_URL_CONTENTS}:1`,
+    "Rule view data URL stylesheet display value matches contents");
+  is(tooltipText, `${STYLESHEET_DECODED_DATA_URL}:1`,
+    "Rule view data URL stylesheet tooltip text matches the full URI path");
+
+  info("Checking the external link label");
+  link = getRuleViewLinkByIndex(view, 2);
+  labelElem = link.querySelector(".ruleview-rule-source-label");
+  value = labelElem.textContent;
+  tooltipText = labelElem.getAttribute("title");
+
+  is(value, `${EXTERNAL_STYLESHEET_FILE_NAME}:1`,
+    "Rule view external stylesheet display value matches filename and line number");
+  is(tooltipText, `${EXTERNAL_STYLESHEET_URL}:1`,
+    "Rule view external stylesheet tooltip text matches the full URI path");
 }
 
 function testUnselectableRuleViewLink(view, index) {

--- a/devtools/shared/inspector/css-logic.js
+++ b/devtools/shared/inspector/css-logic.js
@@ -8,6 +8,8 @@
 
 const { getRootBindingParent } = require("devtools/shared/layout/utils");
 
+const MAX_DATA_URL_LENGTH = 40;
+
 /*
  * About the objects defined in this file:
  * - CssLogic contains style information about a view context. It provides
@@ -105,6 +107,13 @@ exports.shortSource = function (sheet) {
     return exports.l10n("rule.sourceInline");
   }
 
+  // If the sheet is a data URL, return a trimmed version of it.
+  let dataUrl = sheet.href.trim().match(/^data:.*?,((?:.|\r|\n)*)$/);
+  if (dataUrl) {
+    return dataUrl[1].length > MAX_DATA_URL_LENGTH ?
+      `${dataUrl[1].substr(0, MAX_DATA_URL_LENGTH - 1)}…` : dataUrl[1];
+  }
+
   // We try, in turn, the filename, filePath, query string, whole thing
   let url = {};
   try {
@@ -125,8 +134,7 @@ exports.shortSource = function (sheet) {
     return url.query;
   }
 
-  let dataUrl = sheet.href.match(/^(data:[^,]*),/);
-  return dataUrl ? dataUrl[1] : sheet.href;
+  return sheet.href;
 };
 
 const TAB_CHARS = "\t";


### PR DESCRIPTION
Before:
![_004_basilisk_001_old](https://user-images.githubusercontent.com/2373486/29612279-04ecd10c-8801-11e7-8b0f-1308100cd614.png)

After:
![_004_basilisk_001_new](https://user-images.githubusercontent.com/2373486/29612284-09113444-8801-11e7-91eb-c72c2b704fa7.png)

An example (Scratchpad):
``` javascript
var STYLESHEET_DATA_URL_CONTENTS = ["#first {",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                      "color: blue;",
                                    "}"].join("\n");
var STYLESHEET_DATA_URL =
      `data:text/css,${encodeURIComponent(STYLESHEET_DATA_URL_CONTENTS)}`;

var DOCUMENT_URL = "data:text/html;charset=utf-8," + encodeURIComponent(`
  <html>
  <head>
  <title>Rule view style editor link test</title>
  <style type="text/css">
  html { color: #000000; }
  div { font-variant: small-caps; color: #000000; }
  .nomatches {color: #ff0000;}</style> <div id="first" style="margin: 10em;
  font-size: 14pt; font-family: helvetica, sans-serif; color: #AAA">
  </style>
  <style>
  div { font-weight: bold; }
  </style>
  <link rel="stylesheet" type="text/css" href="${STYLESHEET_DATA_URL}">
  </head>
  <body>
  <h1>Some header text</h1>
  <p id="salutation" style="font-size: 12pt">hi.</p>
  <p id="body" style="font-size: 12pt">I am a test-case. This text exists
  solely to provide some things to
  <span style="color: yellow" class="highlight">
  highlight</span> and <span style="font-weight: bold">count</span>
  style list-items in the box at right. If you are reading this,
  you should go do something else instead. Maybe read a book. Or better
  yet, write some test-cases for another bit of code.
  <span style="font-style: italic">some text</span></p>
  <p id="closing">more text</p>
  <p>even more text</p>
  </div>
  </body>
  </html>
`);
window.open(DOCUMENT_URL);
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1360868

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
