### PR TITLE
[minor fix] about:preferences#general homepage - [RTL] wrong direction

### DIFF
--- a/browser/themes/shared/incontentprefs/preferences.inc.css
+++ b/browser/themes/shared/incontentprefs/preferences.inc.css
@@ -179,6 +179,11 @@ treecol {
   margin-inline-start: 0;
 }
 
+#browserHomePage:-moz-locale-dir(rtl) input {
+  unicode-bidi: plaintext;
+  direction: rtl;
+}
+
 /* Content pane */
 
 #defaultFontSizeLabel {


### PR DESCRIPTION
An example - `about:config`:
`intl.uidirection.en-US` = `rtl`

Before:
![_001_before](https://user-images.githubusercontent.com/2373486/29748215-fd229b50-8b11-11e7-9ae2-ccb32acf1608.png)

After:
![_002_after](https://user-images.githubusercontent.com/2373486/29748216-03c8bc6e-8b12-11e7-8e70-ee2f14fd7106.png)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1217907

---

I've created the new build (x32, Windows) and tested.
