### PR TITLE
Plugins - Cross-origin iframe hides Flash from navigator.plugins even when the Flash status is "always activate"

### DIFF
--- a/browser/base/content/test/plugins/browser.ini
+++ b/browser/base/content/test/plugins/browser.ini
@@ -76,4 +76,4 @@ skip-if = !crashreporter
 [browser_pluginCrashReportNonDeterminism.js]
 skip-if = !crashreporter || os == 'linux' # Bug 1152811
 [browser_private_clicktoplay.js]
-
+[browser_subframe_access_hidden_plugins.js]

--- a/browser/base/content/test/plugins/browser_subframe_access_hidden_plugins.js
+++ b/browser/base/content/test/plugins/browser_subframe_access_hidden_plugins.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const TEST_PLUGIN_NAME = "Test Plug-in";
+const HIDDEN_CTP_PLUGIN_PREF = "plugins.navigator.hidden_ctp_plugin";
+const DOMAIN_1 = "http://example.com";
+const DOMAIN_2 = "http://mochi.test:8888";
+
+/**
+ * If a plugin is click-to-play and named in HIDDEN_CTP_PLUGIN_PREF,
+ * then the plugin should be hidden in the navigator.plugins list by
+ * default. However, if a plugin has been allowed on a top-level
+ * document, we should let subframes of that document access
+ * navigator.plugins without showing the notification bar.
+ */
+add_task(function* setup() {
+  // We'll make the Test Plugin click-to-play.
+  let originalPluginState = getTestPluginEnabledState();
+  setTestPluginEnabledState(Ci.nsIPluginTag.STATE_CLICKTOPLAY);
+  registerCleanupFunction(() => {
+    setTestPluginEnabledState(originalPluginState);
+    clearAllPluginPermissions();
+  });
+
+  // And then make the plugin hidden.
+  yield SpecialPowers.pushPrefEnv({
+    set: [[HIDDEN_CTP_PLUGIN_PREF, TEST_PLUGIN_NAME]],
+  });
+});
+
+add_task(function* test_plugin_accessible_in_subframe() {
+  // Let's make it so that DOMAIN_1 allows the test plugin to
+  // be activated. This permission will be cleaned up inside
+  // our registerCleanupFunction when the test ends.
+  let ssm = Services.scriptSecurityManager;
+  let principal = ssm.createCodebasePrincipalFromOrigin(DOMAIN_1);
+  let pluginHost = Cc["@mozilla.org/plugin/host;1"]
+                     .getService(Ci.nsIPluginHost);
+  let permString = pluginHost.getPermissionStringForType("application/x-test");
+  Services.perms.addFromPrincipal(principal, permString,
+                                  Ci.nsIPermissionManager.ALLOW_ACTION,
+                                  Ci.nsIPermissionManager.EXPIRE_NEVER,
+                                  0 /* expireTime */);
+
+  yield BrowserTestUtils.withNewTab({
+    gBrowser,
+    url: DOMAIN_1
+  }, function*(browser) {
+    yield ContentTask.spawn(browser, [TEST_PLUGIN_NAME, DOMAIN_2],
+                            function*([pluginName, domain2]) {
+      Assert.ok(content.navigator.plugins[pluginName],
+                "Top-level document should find Test Plugin");
+
+      // Now manually create a subframe hosted at domain2...
+      let subframe = content.document.createElement("iframe");
+      subframe.src = domain2;
+      let loadedPromise = ContentTaskUtils.waitForEvent(subframe, "load");
+      content.document.body.appendChild(subframe);
+      yield loadedPromise;
+
+      // Instead of waiting for a notification bar that should never come,
+      // we'll make sure that the HiddenPlugin event never fires in content
+      // (which is the event that triggers the notification bar).
+      let sawEvent = false;
+      addEventListener("HiddenPlugin", function onHiddenPlugin(e) {
+        sawEvent = true;
+        removeEventListener("HiddenPlugin", onHiddenPlugin, true);
+      }, true);
+
+      Assert.ok(subframe.contentWindow.navigator.plugins[pluginName],
+                "Subframe should find Test Plugin");
+      Assert.ok(!sawEvent, "Should not have seen the HiddenPlugin event.");
+    });
+  });
+});

--- a/dom/base/nsPluginArray.cpp
+++ b/dom/base/nsPluginArray.cpp
@@ -372,9 +372,21 @@ nsPluginArray::EnsurePlugins()
           nsCString permString;
           nsresult rv = pluginHost->GetPermissionStringForTag(pluginTag, 0, permString);
           if (rv == NS_OK) {
-            nsIPrincipal* principal = mWindow->GetExtantDoc()->NodePrincipal();
-            nsCOMPtr<nsIPermissionManager> permMgr = services::GetPermissionManager();
-            permMgr->TestPermissionFromPrincipal(principal, permString.get(), &permission);
+            nsCOMPtr<nsIDocument> currentDoc = mWindow->GetExtantDoc();
+
+            // The top-level content document gets the final say on whether or not
+            // a plugin is going to be hidden or not, regardless of the origin
+            // that a subframe is hosted at. This is to avoid spamming the user
+            // with the hidden plugin notification bar when third-party iframes
+            // attempt to access navigator.plugins after the user has already
+            // expressed that the top-level document has this permission.
+            nsCOMPtr<nsIDocument> topDoc = currentDoc->GetTopLevelContentDocument();
+
+            if (topDoc) {
+              nsIPrincipal* principal = topDoc->NodePrincipal();
+              nsCOMPtr<nsIPermissionManager> permMgr = services::GetPermissionManager();
+              permMgr->TestPermissionFromPrincipal(principal, permString.get(), &permission);
+            }
           }
         }
       }


### PR DESCRIPTION
__Steps to reproduce:__
On Nightly with the default pref "plugins.navigator.hidden_ctp_plugin" set to "Shockwave Flash"
Set Flash as ask-to-activate
Load http://www.kongregate.com/games/Ninjakiwi/bloons-monkey-city
See the "Manage plug-in use" icon, click it and choose "Activate Now"
Reload the page

__Actual results:__
The page continues to say Flash is not available

__Expected results:__
The page should load with Flash activated

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1312091

---

I've created the new build (x32, Windows) and tested.
