### PR TITLE
HTML - input - datetime - Datepicker shows incorrect month for the first day of the month

### DIFF
--- a/toolkit/content/widgets/datepicker.js
+++ b/toolkit/content/widgets/datepicker.js
@@ -276,9 +276,11 @@ function DatePicker(context) {
    */
   function MonthYear(options, context) {
     const spinnerSize = 5;
-    const yearFormat = new Intl.DateTimeFormat(options.locale, { year: "numeric" }).format;
-    const dateFormat = new Intl.DateTimeFormat(options.locale, { year: "numeric", month: "long" }).format;
-
+    const yearFormat = new Intl.DateTimeFormat(options.locale, { year: "numeric",
+                                                                 timeZone: "UTC" }).format;
+    const dateFormat = new Intl.DateTimeFormat(options.locale, { year: "numeric",
+                                                                 month: "long",
+                                                                 timeZone: "UTC" }).format;
     this.context = context;
     this.state = { dateFormat };
     this.props = {};
@@ -296,7 +298,7 @@ function DatePicker(context) {
           this.state.isYearSet = true;
           options.setYear(year);
         },
-        getDisplayString: year => yearFormat(new Date(new Date(0).setFullYear(year))),
+        getDisplayString: year => yearFormat(new Date(new Date(0).setUTCFullYear(year))),
         viewportSize: spinnerSize
       }, context.monthYearView)
     };


### PR DESCRIPTION
Ad #92 (improvements)
[Bug 1331608](https://bugzilla.mozilla.org/show_bug.cgi?id=1331608) - [DateTimePicker] months appear twice or not at all in month picker due to daylight savings time (e.g. March, October)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1370671

---

I've created the new build (x32, Windows) but I have no example for this now.
