### PR TITLE
DevTools - Browser Console - restore sessions

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -7931,7 +7931,7 @@ var TabContextMenu = {
 Object.defineProperty(this, "HUDService", {
   get: function HUDService_getter() {
     let devtools = Cu.import("resource://devtools/shared/Loader.jsm", {}).devtools;
-    return devtools.require("devtools/client/webconsole/hudservice");
+    return devtools.require("devtools/client/webconsole/hudservice").HUDService;
   },
   configurable: true,
   enumerable: true

--- a/browser/components/sessionstore/SessionStore.jsm
+++ b/browser/components/sessionstore/SessionStore.jsm
@@ -189,6 +189,15 @@ XPCOMUtils.defineLazyModuleGetter(this, "ViewSourceBrowser",
 XPCOMUtils.defineLazyModuleGetter(this, "AsyncShutdown",
   "resource://gre/modules/AsyncShutdown.jsm");
 
+Object.defineProperty(this, "HUDService", {
+  get: function HUDService_getter() {
+    let devtools = Cu.import("resource://devtools/shared/Loader.jsm", {}).devtools;
+    return devtools.require("devtools/client/webconsole/hudservice").HUDService;
+  },
+  configurable: true,
+  enumerable: true
+});
+
 /**
  * |true| if we are in debug mode, |false| otherwise.
  * Debug mode is controlled by preference browser.sessionstore.debug
@@ -2675,8 +2684,14 @@ var SessionStoreInternal = {
       this._closedObjectsChanged = true;
     }
 
+    // Scratchpad
     if (lastSessionState.scratchpads) {
       ScratchpadManager.restoreSession(lastSessionState.scratchpads);
+    }
+
+    // The Browser Console
+    if (lastSessionState.browserConsole) {
+      HUDService.restoreBrowserConsoleSession();
     }
 
     // Set data that persists between sessions
@@ -3044,6 +3059,7 @@ var SessionStoreInternal = {
       global: this._globalState.getState()
     };
 
+    // Scratchpad
     if (Cu.isModuleLoaded("resource://devtools/client/scratchpad/scratchpad-manager.jsm")) {
       // get open Scratchpad window states too
       let scratchpads = ScratchpadManager.getSessionState();
@@ -3051,6 +3067,9 @@ var SessionStoreInternal = {
         state.scratchpads = scratchpads;
       }
     }
+
+    // The Browser Console
+    state.browserConsole = HUDService.getBrowserConsoleSessionState();
 
     // Persist the last session if we deferred restoring it
     if (LastSession.canRestore) {
@@ -3404,8 +3423,14 @@ var SessionStoreInternal = {
 
     this.restoreWindow(aWindow, root.windows[0], aOptions);
 
+    // Scratchpad
     if (aState.scratchpads) {
       ScratchpadManager.restoreSession(aState.scratchpads);
+    }
+
+    // The Browser Console
+    if (aState.browserConsole) {
+      HUDService.restoreBrowserConsoleSession();
     }
   },
 

--- a/devtools/bootstrap.js
+++ b/devtools/bootstrap.js
@@ -187,7 +187,7 @@ function reload(event) {
   // HUDService is going to close it on unload.
   // Instead we have to manually toggle it.
   if (reopenBrowserConsole) {
-    let HUDService = devtools.require("devtools/client/webconsole/hudservice");
+    let {HUDService} = devtools.require("devtools/client/webconsole/hudservice");
     HUDService.toggleBrowserConsole();
   }
 

--- a/devtools/client/commandline/test/browser_cmd_commands.js
+++ b/devtools/client/commandline/test/browser_cmd_commands.js
@@ -4,7 +4,7 @@
 // Test various GCLI commands
 
 const TEST_URI = "data:text/html;charset=utf-8,gcli-commands";
-const HUDService = require("devtools/client/webconsole/hudservice");
+const {HUDService} = require("devtools/client/webconsole/hudservice");
 
 // Use the old webconsole since pprint isn't working on new one (Bug 1304794)
 Services.prefs.setBoolPref("devtools.webconsole.new-frontend-enabled", false);

--- a/devtools/client/devtools-startup.js
+++ b/devtools/client/devtools-startup.js
@@ -75,9 +75,9 @@ DevToolsStartup.prototype = {
       this.initDevTools();
 
       let { require } = Cu.import("resource://devtools/shared/Loader.jsm", {});
-      let hudservice = require("devtools/client/webconsole/hudservice");
+      let { HUDService } = require("devtools/client/webconsole/hudservice");
       let { console } = Cu.import("resource://gre/modules/Console.jsm", {});
-      hudservice.toggleBrowserConsole().then(null, console.error);
+      HUDService.toggleBrowserConsole().then(null, console.error);
     } else {
       // the Browser Console was already open
       window.focus();

--- a/devtools/client/framework/toolbox.js
+++ b/devtools/client/framework/toolbox.js
@@ -63,7 +63,7 @@ loader.lazyRequireGetter(this, "ToolboxButtons",
 loader.lazyRequireGetter(this, "SourceMapService",
   "devtools/client/framework/source-map-service", true);
 loader.lazyRequireGetter(this, "HUDService",
-  "devtools/client/webconsole/hudservice");
+  "devtools/client/webconsole/hudservice", true);
 loader.lazyRequireGetter(this, "viewSource",
   "devtools/client/shared/view-source");
 

--- a/devtools/client/menus.js
+++ b/devtools/client/menus.js
@@ -120,7 +120,7 @@ exports.menuitems = [
   { id: "menu_browserConsole",
     l10nKey: "browserConsoleCmd",
     oncommand() {
-      let HUDService = require("devtools/client/webconsole/hudservice");
+      let {HUDService} = require("devtools/client/webconsole/hudservice");
       HUDService.openBrowserConsoleOrFocus();
     },
     key: {

--- a/devtools/client/scratchpad/scratchpad.js
+++ b/devtools/client/scratchpad/scratchpad.js
@@ -81,7 +81,7 @@ loader.lazyRequireGetter(this, "DebuggerServer", "devtools/server/main", true);
 loader.lazyRequireGetter(this, "DebuggerClient", "devtools/shared/client/main", true);
 loader.lazyRequireGetter(this, "EnvironmentClient", "devtools/shared/client/main", true);
 loader.lazyRequireGetter(this, "ObjectClient", "devtools/shared/client/main", true);
-loader.lazyRequireGetter(this, "HUDService", "devtools/client/webconsole/hudservice");
+loader.lazyRequireGetter(this, "HUDService", "devtools/client/webconsole/hudservice", true);
 
 XPCOMUtils.defineLazyGetter(this, "REMOTE_TIMEOUT", () =>
   Services.prefs.getIntPref("devtools.debugger.remote-timeout"));

--- a/devtools/client/scratchpad/test/browser_scratchpad_open_error_console.js
+++ b/devtools/client/scratchpad/test/browser_scratchpad_open_error_console.js
@@ -2,7 +2,7 @@
 /* Any copyright is dedicated to the Public Domain.
    http://creativecommons.org/publicdomain/zero/1.0/ */
 
-const HUDService = require("devtools/client/webconsole/hudservice");
+const {HUDService} = require("devtools/client/webconsole/hudservice");
 
 function test()
 {

--- a/devtools/client/webconsole/hudservice.js
+++ b/devtools/client/webconsole/hudservice.js
@@ -51,6 +51,23 @@ HUD_SERVICE.prototype =
    */
   consoles: null,
 
+  _browerConsoleSessionState: false,
+  storeBrowserConsoleSessionState() {
+    this._browerConsoleSessionState = !!this.getBrowserConsole();
+  },
+  getBrowserConsoleSessionState() {
+    return this._browerConsoleSessionState;
+  },
+
+  /**
+   * Restore the Browser Console as provided by SessionStore.
+   */
+  restoreBrowserConsoleSession: function HS_restoreBrowserConsoleSession() {
+    if (!HUDService.getBrowserConsole()) {
+      HUDService.toggleBrowserConsole();
+    }
+  },
+
   /**
    * Assign a function to this property to listen for every request that
    * completes. Used by unit tests. The callback takes one argument: the HTTP
@@ -647,6 +664,9 @@ BrowserConsole.prototype = extend(WebConsole.prototype, {
       return this._bc_init;
     }
 
+    // Only add the shutdown observer if we've opened a Browser Console window.
+    ShutdownObserver.init();
+
     this.ui._filterPrefsPrefix = BROWSER_CONSOLE_FILTER_PREFS_PREFIX;
 
     let window = this.iframeWindow;
@@ -703,16 +723,32 @@ BrowserConsole.prototype = extend(WebConsole.prototype, {
 });
 
 const HUDService = new HUD_SERVICE();
+exports.HUDService = HUDService;
 
-(() => {
-  let methods = ["openWebConsole", "openBrowserConsole",
-                 "toggleBrowserConsole", "getOpenWebConsole",
-                 "getBrowserConsole", "getHudByWindow",
-                 "openBrowserConsoleOrFocus", "getHudReferenceById"];
-  for (let method of methods) {
-    exports[method] = HUDService[method].bind(HUDService);
+/**
+ * The ShutdownObserver listens for app shutdown and saves the current state
+ * of the Browser Console for session restore.
+ */
+var ShutdownObserver = {
+  _initialized: false,
+  init() {
+    if (this._initialized) {
+      return;
+    }
+
+    Services.obs.addObserver(this, "quit-application-granted", false);
+
+    this._initialized = true;
+  },
+
+  observe(message, topic) {
+    if (topic == "quit-application-granted") {
+      HUDService.storeBrowserConsoleSessionState();
+      this.uninit();
+    }
+  },
+
+  uninit() {
+    Services.obs.removeObserver(this, "quit-application-granted");
   }
-
-  exports.consoles = HUDService.consoles;
-  exports.lastFinishedRequest = HUDService.lastFinishedRequest;
-})();
+};

--- a/devtools/client/webconsole/panel.js
+++ b/devtools/client/webconsole/panel.js
@@ -8,7 +8,7 @@
 
 const promise = require("promise");
 
-loader.lazyGetter(this, "HUDService", () => require("devtools/client/webconsole/hudservice"));
+loader.lazyRequireGetter(this, "HUDService", "devtools/client/webconsole/hudservice", true);
 loader.lazyGetter(this, "EventEmitter", () => require("devtools/shared/event-emitter"));
 
 /**

--- a/devtools/client/webconsole/test/browser.ini
+++ b/devtools/client/webconsole/test/browser.ini
@@ -186,6 +186,7 @@ skip-if = true # Bug 1298364
 [browser_console_optimized_out_vars.js]
 [browser_console_private_browsing.js]
 skip-if = e10s # Bug 1042253 - webconsole e10s tests
+[browser_console_restore.js]
 [browser_console_server_logging.js]
 [browser_console_variables_view.js]
 [browser_console_variables_view_filter.js]

--- a/devtools/client/webconsole/test/browser_console.js
+++ b/devtools/client/webconsole/test/browser_console.js
@@ -22,7 +22,7 @@ const TEST_IMAGE = "http://example.com/browser/devtools/client/webconsole/" +
 add_task(function* () {
   yield loadTab(TEST_URI);
 
-  let opened = waitForConsole();
+  let opened = waitForBrowserConsole();
 
   let hud = HUDService.getBrowserConsole();
   ok(!hud, "browser console is not open");
@@ -140,21 +140,4 @@ function consoleOpened(hud) {
       },
     ],
   });
-}
-
-function waitForConsole() {
-  let deferred = promise.defer();
-
-  Services.obs.addObserver(function observer(aSubject) {
-    Services.obs.removeObserver(observer, "web-console-created");
-    aSubject.QueryInterface(Ci.nsISupportsString);
-
-    let hud = HUDService.getBrowserConsole();
-    ok(hud, "browser console is open");
-    is(aSubject.data, hud.hudId, "notification hudId is correct");
-
-    executeSoon(() => deferred.resolve(hud));
-  }, "web-console-created", false);
-
-  return deferred.promise;
 }

--- a/devtools/client/webconsole/test/browser_console_restore.js
+++ b/devtools/client/webconsole/test/browser_console_restore.js
@@ -1,0 +1,30 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Check that the browser console gets session state is set correctly, and that
+// it re-opens when restore is requested.
+
+"use strict";
+
+add_task(function* () {
+  is(HUDService.getBrowserConsoleSessionState(), false, "Session state false by default");
+  HUDService.storeBrowserConsoleSessionState();
+  is(HUDService.getBrowserConsoleSessionState(), false,
+    "Session state still not true even after setting (since Browser Console is closed)");
+
+  yield HUDService.toggleBrowserConsole();
+  HUDService.storeBrowserConsoleSessionState();
+  is(HUDService.getBrowserConsoleSessionState(), true,
+    "Session state true (since Browser Console is opened)");
+
+  info("Closing the browser console and waiting for the session restore to reopen it")
+  yield HUDService.toggleBrowserConsole();
+
+  let opened = waitForBrowserConsole();
+  HUDService.restoreBrowserConsoleSession();
+
+  info("Waiting for the console to open after session restore")
+  yield opened;
+});

--- a/devtools/client/webconsole/test/head.js
+++ b/devtools/client/webconsole/test/head.js
@@ -12,7 +12,7 @@ Services.scriptloader.loadSubScript("chrome://mochitests/content/browser/devtool
 var {Utils: WebConsoleUtils} = require("devtools/client/webconsole/utils");
 var {Messages} = require("devtools/client/webconsole/console-output");
 const asyncStorage = require("devtools/shared/async-storage");
-const HUDService = require("devtools/client/webconsole/hudservice");
+const {HUDService} = require("devtools/client/webconsole/hudservice");
 
 // Services.prefs.setBoolPref("devtools.debugger.log", true);
 
@@ -1807,4 +1807,19 @@ function getRenderedSource(root) {
     line: location.getAttribute("data-line"),
     column: location.getAttribute("data-column"),
   } : null;
+}
+
+function waitForBrowserConsole() {
+  return new Promise(resolve => {
+    Services.obs.addObserver(function observer(subject) {
+      Services.obs.removeObserver(observer, "web-console-created");
+      subject.QueryInterface(Ci.nsISupportsString);
+
+      let hud = HUDService.getBrowserConsole();
+      ok(hud, "browser console is open");
+      is(subject.data, hud.hudId, "notification hudId is correct");
+
+      executeSoon(() => resolve(hud));
+    }, "web-console-created");
+  });
 }

--- a/toolkit/components/extensions/ext-c-backgroundPage.js
+++ b/toolkit/components/extensions/ext-c-backgroundPage.js
@@ -9,8 +9,8 @@ global.initializeBackgroundPage = (contentWindow) => {
     if (!alertDisplayedWarning) {
       require("devtools/client/framework/devtools-browser");
 
-      let hudservice = require("devtools/client/webconsole/hudservice");
-      hudservice.openBrowserConsoleOrFocus();
+      let {HUDService} = require("devtools/client/webconsole/hudservice");
+      HUDService.openBrowserConsoleOrFocus();
 
       contentWindow.console.warn("alert() is not supported in background windows; please use console.log instead.");
 

--- a/toolkit/components/extensions/test/mochitest/test_chrome_ext_background_page.html
+++ b/toolkit/components/extensions/test/mochitest/test_chrome_ext_background_page.html
@@ -66,14 +66,14 @@ add_task(function* testAlertNotShownInBackgroundWindow() {
 
   let {require} = Cu.import("resource://devtools/shared/Loader.jsm", {});
   require("devtools/client/framework/devtools-browser");
-  let hudservice = require("devtools/client/webconsole/hudservice");
+  let {HUDService} = require("devtools/client/webconsole/hudservice");
 
   // And then double check that we have an actual browser console.
-  let haveConsole = !!hudservice.getBrowserConsole();
+  let haveConsole = !!HUDService.getBrowserConsole();
   ok(haveConsole, "Expected browser console to be open");
 
   if (haveConsole) {
-    yield hudservice.toggleBrowserConsole();
+    yield HUDService.toggleBrowserConsole();
   }
 
   yield extension.unload();


### PR DESCRIPTION
__Restore the Browser Console window__

An example:
- Open the Browser Console
- Restart the browser
(The menu: Help - Troubleshooting Information - Restart normally...)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1388552 (partially)

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
