### PR TITLE
Login Manager Prompter - auth - throws an errors

### DIFF
--- a/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
+++ b/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
@@ -808,6 +808,9 @@ LoginManagerPrompter.prototype = {
    */
   _showLoginCaptureDoorhanger(login, type) {
     let { browser } = this._getNotifyWindow();
+    if (!browser) {
+      return;
+    }
 
     let saveMsgNames = {
       prompt: login.username === "" ? "saveLoginMsgNoUser"
@@ -1420,10 +1423,34 @@ LoginManagerPrompter.prototype = {
    * Given a content DOM window, returns the chrome window and browser it's in.
    */
   _getChromeWindow(aWindow) {
+    // Handle non-e10s toolkit consumers.
+    if (!Cu.isCrossProcessWrapper(aWindow)) {
+      let chromeWin = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                             .getInterface(Ci.nsIWebNavigation)
+                             .QueryInterface(Ci.nsIDocShell)
+                             .chromeEventHandler.ownerGlobal;
+      if (!chromeWin) {
+        return null;
+      }
+
+      // gBrowser only exists on some apps, like Firefox.
+      let tabbrowser = chromeWin.gBrowser ||
+        (typeof chromeWin.getBrowser == "function" ? chromeWin.getBrowser() : null);
+      // At least serve the chrome window if getBrowser()
+      // or getBrowserForContentWindow() are not supported.
+      if (!tabbrowser || typeof tabbrowser.getBrowserForContentWindow != "function") {
+        return { win: chromeWin };
+      }
+
+      let browser = tabbrowser.getBrowserForContentWindow(aWindow);
+      return { win: chromeWin, browser };
+    }
+
     let windows = Services.wm.getEnumerator(null);
     while (windows.hasMoreElements()) {
       let win = windows.getNext();
-      let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
+      let tabbrowser = win.gBrowser || win.getBrowser();
+      let browser = tabbrowser.getBrowserForContentWindow(aWindow);
       if (browser) {
         return { win, browser };
       }


### PR DESCRIPTION
__Steps to reproduce__
- open the browser (a non-private window)
- go to: https://github.com/greasemonkey/greasemonkey/issues/1717
- go to: http://kraehen.org/test/test.user.js (with HTTP Digest Auth)
(enter the correct login and password for authentication)
- open new private window
- go to: https://github.com/greasemonkey/greasemonkey/issues/1717
- go to: http://kraehen.org/test/test.user.js (with HTTP Digest Auth)

Throws an errors in Browser Console:
```
TypeError: win.gBrowser is undefined
nsLoginManagerPrompter.js:1426:11

nsPrompter: Delegation to password manager failed:
[Exception... "[JavaScript Error: "win.gBrowser is undefined"
{file: "resource://gre/components/nsLoginManagerPrompter.js" line: 1426}]
'[JavaScript Error: "win.gBrowser is undefined"
{file: "resource://gre/components/nsLoginManagerPrompter.js" line: 1426}]
' when calling method: [nsIPromptFactory::getPrompt]"
nsresult: "0x80570021 (NS_ERROR_XPC_JAVASCRIPT_ERROR_WITH_DETAILS)"
location: "JS frame :: resource://gre/components/nsPrompter.js
:: getPrompt :: line 42"  data: yes]
nsPrompter.js:44

uncaught exception: 2147500033  (unknown)

TypeError: checkValue is undefined
nsPrompter.js:766:13
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1350152
https://bugzilla.mozilla.org/show_bug.cgi?id=1388166

---

I've created the new build (x32, Windows) and tested.
