### PR TITLE
JS - DOM - Events - support createEvent("FocusEvent")

### DIFF
--- a/dom/events/EventDispatcher.cpp
+++ b/dom/events/EventDispatcher.cpp
@@ -1164,6 +1164,11 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
     event->MarkUninitialized();
     return event.forget();
   }
+  if (aEventType.LowerCaseEqualsLiteral("focusevent")) {
+    RefPtr<Event> event = NS_NewDOMFocusEvent(aOwner, aPresContext, nullptr);
+    event->MarkUninitialized();
+    return event.forget();
+  }
 
 #undef LOG_EVENT_CREATION
 

--- a/testing/web-platform/meta/dom/events/EventTarget-dispatchEvent.html.ini
+++ b/testing/web-platform/meta/dom/events/EventTarget-dispatchEvent.html.ini
@@ -12,10 +12,6 @@
     expected: FAIL
     bug: https://github.com/whatwg/dom/issues/362, 1314303
 
-  [If the event's initialized flag is not set, an InvalidStateError must be thrown (FocusEvent).]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
   [If the event's initialized flag is not set, an InvalidStateError must be thrown (IDBVersionChangeEvent).]
     expected: FAIL
     bug: https://github.com/whatwg/dom/issues/362, 1314303

--- a/testing/web-platform/meta/dom/nodes/Document-createEvent.html.ini
+++ b/testing/web-platform/meta/dom/nodes/Document-createEvent.html.ini
@@ -76,30 +76,6 @@
     expected: FAIL
     bug: https://github.com/whatwg/dom/issues/362, 1314303
 
-  [FocusEvent should be an alias for FocusEvent.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
-  [createEvent('FocusEvent') should be initialized correctly.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
-  [focusevent should be an alias for FocusEvent.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
-  [createEvent('focusevent') should be initialized correctly.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
-  [FOCUSEVENT should be an alias for FocusEvent.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
-  [createEvent('FOCUSEVENT') should be initialized correctly.]
-    expected: FAIL
-    bug: https://github.com/whatwg/dom/issues/362, 1314303
-
   [IDBVersionChangeEvent should be an alias for IDBVersionChangeEvent.]
     expected: FAIL
     bug: https://github.com/whatwg/dom/issues/362, 1314303


### PR DESCRIPTION
Ad #122

__Steps to reproduce__

Scratchpad:
`alert(document.createEvent("FocusEvent"));`

Actual results:
`Exception: NotSupportedError: Operation is not supported`

Expected results:
[object FocusEvent]

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1388069

---

I've created the new build (x32, Windows) and tested.
