### PR TITLE
Silence compiler warnings

### DIFF
--- a/media/ffvpx/ffvpxcommon.mozbuild
+++ b/media/ffvpx/ffvpxcommon.mozbuild
@@ -43,7 +43,10 @@ if CONFIG['GNU_CC']:
         '-Wno-switch',
         '-Wno-type-limits',
         '-Wno-unused-function',
+        # XXX This does not seem to have any effect on some versions of GCC.
         '-Wno-deprecated-declarations',
+        '-Wno-discarded-qualifiers',
+        '-Wno-maybe-uninitialized',
     ]
     if CONFIG['CLANG_CXX']:
         CFLAGS += [

--- a/media/ffvpx/ffvpxcommon.mozbuild
+++ b/media/ffvpx/ffvpxcommon.mozbuild
@@ -76,6 +76,8 @@ elif CONFIG['_MSC_VER']:
         '-wd4245', # conversion from 'int' to 'uint32_t', signed/unsigned mismatch
         '-wd4703', # potentially uninitialized local pointer
         '-wd4293', # '<<' : shift count negative or too big, undefined behavior
+        '-wd4334', # '<<' : result of 32-bit shift implicitly converted to 64 bits
+        '-wd4996', # The compiler encountered a deprecated declaration.
         # from FFmpeg configure
         '-wd4244', '-wd4127', '-wd4018', '-wd4389', '-wd4146', '-wd4701',
         '-wd4057', '-wd4204', '-wd4706', '-wd4305', '-wd4152', '-wd4324',

--- a/media/ffvpx/ffvpxcommon.mozbuild
+++ b/media/ffvpx/ffvpxcommon.mozbuild
@@ -51,7 +51,8 @@ if CONFIG['GNU_CC']:
     if CONFIG['CLANG_CXX']:
         CFLAGS += [
             '-Wno-incompatible-pointer-types-discards-qualifiers',
-            '-Wno-logical-op-parentheses',
+            '-Wno-string-conversion',
+            '-Wno-visibility',
         ]
     # Force visibility of cpu and av_log symbols.
     CFLAGS += ['-include', 'libavutil_visibility.h']

--- a/media/ffvpx/ffvpxcommon.mozbuild
+++ b/media/ffvpx/ffvpxcommon.mozbuild
@@ -45,14 +45,17 @@ if CONFIG['GNU_CC']:
         '-Wno-unused-function',
         # XXX This does not seem to have any effect on some versions of GCC.
         '-Wno-deprecated-declarations',
-        '-Wno-discarded-qualifiers',
-        '-Wno-maybe-uninitialized',
     ]
     if CONFIG['CLANG_CXX']:
         CFLAGS += [
             '-Wno-incompatible-pointer-types-discards-qualifiers',
             '-Wno-string-conversion',
             '-Wno-visibility',
+        ]
+    else:
+        CFLAGS += [
+            '-Wno-discarded-qualifiers',
+            '-Wno-maybe-uninitialized',
         ]
     # Force visibility of cpu and av_log symbols.
     CFLAGS += ['-include', 'libavutil_visibility.h']


### PR DESCRIPTION
Just what it says in the tin. Silence warnings we don't particularly care about in 3rd party code with all supported compilers.

Built with GCC 5.3 and lightly tested. No issues seen.