### PR TITLE
(follow up) URL parser - stop preserving empty passwords

### DIFF
--- a/docshell/test/unit/test_nsDefaultURIFixup_search.js
+++ b/docshell/test/unit/test_nsDefaultURIFixup_search.js
@@ -74,7 +74,7 @@ var data = [
   },
   {
     wrong: 'user:@example.com:8080/this/is/a/test.html',
-    fixed: 'http://user:@example.com:8080/this/is/a/test.html',
+    fixed: 'http://user@example.com:8080/this/is/a/test.html',
   },
   {
     wrong: '//user:pass@example.com:8080/this/is/a/test.html',

--- a/netwerk/base/nsStandardURL.cpp
+++ b/netwerk/base/nsStandardURL.cpp
@@ -727,11 +727,13 @@ nsStandardURL::BuildNormalizedSpec(const char *spec)
         i = AppendSegmentToBuf(buf, i, spec, username, mUsername,
                                &encUsername, useEncUsername, &diff);
         ShiftFromPassword(diff);
-        if (password.mLen >= 0) {
+        if (password.mLen > 0) {
             buf[i++] = ':';
             i = AppendSegmentToBuf(buf, i, spec, password, mPassword,
                                    &encPassword, useEncPassword, &diff);
             ShiftFromHost(diff);
+        } else {
+            mPassword.mLen = -1;
         }
         buf[i++] = '@';
     }
@@ -1561,7 +1563,7 @@ nsStandardURL::SetUserPass(const nsACString &input)
                                                             usernameLen),
                                                  esc_Username | esc_AlwaysCopy,
                                                  buf, ignoredOut);
-        if (passwordLen >= 0) {
+        if (passwordLen > 0) {
             buf.Append(':');
             passwordLen = encoder.EncodeSegmentCount(userpass.get(),
                                                      URLSegment(passwordPos,
@@ -1569,6 +1571,8 @@ nsStandardURL::SetUserPass(const nsACString &input)
                                                      esc_Password |
                                                      esc_AlwaysCopy, buf,
                                                      ignoredOut);
+        } else {
+            passwordLen = -1;
         }
         if (mUsername.mLen < 0)
             buf.Append('@');
@@ -1599,8 +1603,9 @@ nsStandardURL::SetUserPass(const nsACString &input)
     // update positions and lengths
     mUsername.mLen = usernameLen;
     mPassword.mLen = passwordLen;
-    if (passwordLen)
+    if (passwordLen > 0) {
         mPassword.mPos = mUsername.mPos + mUsername.mLen + 1;
+    }
 
     return NS_OK;
 }

--- a/netwerk/test/unit/test_URIs.js
+++ b/netwerk/test/unit/test_URIs.js
@@ -121,7 +121,7 @@ var gTests = [
     nsIURL:  true, nsINestedURI: false },
   { spec:    "ftp://foo:@ftp.mozilla.org:100/pub/mozilla.org/README",
     scheme:  "ftp",
-    prePath: "ftp://foo:@ftp.mozilla.org:100",
+    prePath: "ftp://foo@ftp.mozilla.org:100",
     port:    100,
     username: "foo",
     password: "",

--- a/netwerk/test/unit/test_standardurl.js
+++ b/netwerk/test/unit/test_standardurl.js
@@ -453,3 +453,23 @@ add_test(function test_invalidHostChars() {
   // hostname separators, so there is no way to set them and fail.
   run_next_test();
 });
+
+add_test(function test_emptyPassword() {
+  var url = stringToURL("http://a:@example.com");
+  do_check_eq(url.spec, "http://a@example.com/");
+  url.password = "pp";
+  do_check_eq(url.spec, "http://a:pp@example.com/");
+  url.password = "";
+  do_check_eq(url.spec, "http://a@example.com/");
+  url.userPass = "xxx:";
+  do_check_eq(url.spec, "http://xxx@example.com/");
+  url.password = "zzzz";
+  do_check_eq(url.spec, "http://xxx:zzzz@example.com/");
+  url.userPass = "xxxxx:yyyyyy";
+  do_check_eq(url.spec, "http://xxxxx:yyyyyy@example.com/");
+  url.userPass = "z:";
+  do_check_eq(url.spec, "http://z@example.com/");
+  url.password = "ppppppppppp";
+  do_check_eq(url.spec, "http://z:ppppppppppp@example.com/");
+  run_next_test();
+});

--- a/testing/web-platform/meta/url/a-element-xhtml.xhtml.ini
+++ b/testing/web-platform/meta/url/a-element-xhtml.xhtml.ini
@@ -423,9 +423,6 @@
   [Parsing: <http://[0:0:0:0:0:0:13.1.68.3\]> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <https://test:@test> against <about:blank>]
-    expected: FAIL
-
   [Parsing: <https://:@test> against <about:blank>]
     expected: FAIL
 
@@ -433,15 +430,6 @@
     expected: FAIL
 
   [Parsing: <non-special://:@test/x> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http://a:@www.example.com> against <about:blank>]
     expected: FAIL
 
   [Parsing: <http://10000000000> against <http://other.com/>]

--- a/testing/web-platform/meta/url/a-element.html.ini
+++ b/testing/web-platform/meta/url/a-element.html.ini
@@ -432,9 +432,6 @@
   [Parsing: <http://[0:0:0:0:0:0:13.1.68.3\]> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <https://test:@test> against <about:blank>]
-    expected: FAIL
-
   [Parsing: <https://:@test> against <about:blank>]
     expected: FAIL
 
@@ -442,15 +439,6 @@
     expected: FAIL
 
   [Parsing: <non-special://:@test/x> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http://a:@www.example.com> against <about:blank>]
     expected: FAIL
 
   [Parsing: <http://10000000000> against <http://other.com/>]

--- a/testing/web-platform/meta/url/url-constructor.html.ini
+++ b/testing/web-platform/meta/url/url-constructor.html.ini
@@ -210,9 +210,6 @@
   [Parsing: <http://[0:0:0:0:0:0:13.1.68.3\]> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <https://test:@test> against <about:blank>]
-    expected: FAIL
-
   [Parsing: <https://:@test> against <about:blank>]
     expected: FAIL
 
@@ -220,15 +217,6 @@
     expected: FAIL
 
   [Parsing: <non-special://:@test/x> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/a:@www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http://a:@www.example.com> against <about:blank>]
     expected: FAIL
 
   [Parsing: <http://foo.bar/baz?qux#foo\x08bar> against <about:blank>]


### PR DESCRIPTION
Follow up #133 - this change did not happen at all (after reverts).

An example (Scratchpad; `Environment` - `Browser`):
``` javascript
var StandardURL = Components.Constructor("@mozilla.org/network/standard-url;1",
                                         "nsIStandardURL",
                                         "init");
var nsIStandardURL = Components.interfaces.nsIStandardURL;

function stringToURL(str) {
  return (new StandardURL(nsIStandardURL.URLTYPE_AUTHORITY, 80,
                          str, "UTF-8", null))
         .QueryInterface(Components.interfaces.nsIURL);
}

function do_check_eq(a, b) {
  var result = null;
  if (a == b) {
    result = true;
  } else {
    result = false;
  }
  console.log(result + ": (" + a + " == " + b + ")");
}

var url = stringToURL("http://a:@example.com");
do_check_eq(url.spec, "http://a@example.com/");
url.password = "pp";
do_check_eq(url.spec, "http://a:pp@example.com/");
url.password = "";
do_check_eq(url.spec, "http://a@example.com/");
url.userPass = "xxx:";
do_check_eq(url.spec, "http://xxx@example.com/");
url.password = "zzzz";
do_check_eq(url.spec, "http://xxx:zzzz@example.com/");
url.userPass = "xxxxx:yyyyyy";
do_check_eq(url.spec, "http://xxxxx:yyyyyy@example.com/");
url.userPass = "z:";
do_check_eq(url.spec, "http://z@example.com/");
url.password = "ppppppppppp";
do_check_eq(url.spec, "http://z:ppppppppppp@example.com/");
```

Expected results:
all == true

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1326175

---

I've created the new build (x32, Windows) and tested.
