### PR TITLE
Fetch - Headers should sort and combine

### DIFF
--- a/dom/fetch/InternalHeaders.h
+++ b/dom/fetch/InternalHeaders.h
@@ -45,14 +45,23 @@ private:
   HeadersGuardEnum mGuard;
   nsTArray<Entry> mList;
 
+  nsTArray<Entry> mSortedList;
+
+  // This boolean is set to true at any writing operation to mList. It's set to
+  // false when mSortedList is regenerated. This happens when the header is
+  // iterated.
+  bool mListDirty;
+
 public:
   explicit InternalHeaders(HeadersGuardEnum aGuard = HeadersGuardEnum::None)
     : mGuard(aGuard)
+    , mListDirty(false)
   {
   }
 
   explicit InternalHeaders(const InternalHeaders& aOther)
     : mGuard(HeadersGuardEnum::None)
+    , mListDirty(true)
   {
     ErrorResult result;
     Fill(aOther, result);
@@ -79,19 +88,22 @@ public:
   bool Has(const nsACString& aName, ErrorResult& aRv) const;
   void Set(const nsACString& aName, const nsACString& aValue, ErrorResult& aRv);
 
-  uint32_t GetIterableLength() const
+  uint32_t GetIterableLength()
   {
-    return mList.Length();
+    MaybeSortList();
+    return mSortedList.Length();
   }
-  const NS_ConvertASCIItoUTF16 GetKeyAtIndex(unsigned aIndex) const
+  const NS_ConvertASCIItoUTF16 GetKeyAtIndex(unsigned aIndex)
   {
-    MOZ_ASSERT(aIndex < mList.Length());
-    return NS_ConvertASCIItoUTF16(mList[aIndex].mName);
+    MaybeSortList();
+    MOZ_ASSERT(aIndex < mSortedList.Length());
+    return NS_ConvertASCIItoUTF16(mSortedList[aIndex].mName);
   }
-  const NS_ConvertASCIItoUTF16 GetValueAtIndex(unsigned aIndex) const
+  const NS_ConvertASCIItoUTF16 GetValueAtIndex(unsigned aIndex)
   {
-    MOZ_ASSERT(aIndex < mList.Length());
-    return NS_ConvertASCIItoUTF16(mList[aIndex].mValue);
+    MaybeSortList();
+    MOZ_ASSERT(aIndex < mSortedList.Length());
+    return NS_ConvertASCIItoUTF16(mSortedList[aIndex].mValue);
   }
 
   void Clear();
@@ -152,6 +164,9 @@ private:
                              const nsACString& aValue);
 
   static bool IsRevalidationHeader(const nsACString& aName);
+
+  void MaybeSortList();
+  void SetListDirty();
 };
 
 } // namespace dom

--- a/dom/tests/mochitest/fetch/test_headers_common.js
+++ b/dom/tests/mochitest/fetch/test_headers_common.js
@@ -213,12 +213,12 @@ function TestHeadersIterator() {
   var value_iter = headers.values();
   var entries_iter = headers.entries();
 
-  arrayEquals(iterate(key_iter), ["foo", "foo", "foo2"], "Correct key iterator");
-  arrayEquals(iterate(value_iter), ["bar", ehsanInflated, "baz2"], "Correct value iterator");
-  arrayEquals(iterate(entries_iter), [["foo", "bar"], ["foo", ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
+  arrayEquals(iterate(key_iter), ["foo", "foo2"], "Correct key iterator");
+  arrayEquals(iterate(value_iter), ["bar, " + ehsanInflated, "baz2"], "Correct value iterator");
+  arrayEquals(iterate(entries_iter), [["foo", "bar, " + ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
 
-  arrayEquals(iterateForOf(headers), [["foo", "bar"], ["foo", ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
-  arrayEquals(iterateForOf(new Headers(headers)), [["foo", "bar"], ["foo", ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
+  arrayEquals(iterateForOf(headers), [["foo", "bar, " + ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
+  arrayEquals(iterateForOf(new Headers(headers)), [["foo", "bar, " + ehsanInflated], ["foo2", "baz2"]], "Correct entries iterator");
 }
 
 function runTest() {

--- a/testing/web-platform/meta/fetch/api/headers/headers-basic.html.ini
+++ b/testing/web-platform/meta/fetch/api/headers/headers-basic.html.ini
@@ -1,19 +1,5 @@
 [headers-basic.html]
   type: testharness
-  [Check keys method]
-    expected: FAIL
-
-  [Check values method]
-    expected: FAIL
-
-  [Check entries method]
-    expected: FAIL
-
-  [Check Symbol.iterator method]
-    expected: FAIL
-
-  [Check forEach method]
-    expected: FAIL
 
   [Create headers with existing headers with custom iterator]
     expected: FAIL


### PR DESCRIPTION
An example:
``` javascript
var headers = new Headers([["1", "a"],["1", "b"]]);
for (let header of headers) {
  console.log(header.toString() === ["1", "a, b"].toString());
}
headers = new Headers([["2", "a"], ["1", "b"], ["2", "b"]]);
var expected = [["1", "b"], ["2", "a, b"]];
var i = 0;
for (let header of headers) {
  console.log(header.toString() === expected[i].toString());
  i++;
}
console.log(i === 2);
```

Excpected result:
\- all values should be TRUE

See:
https://github.com/whatwg/fetch/issues/506
https://bugzilla.mozilla.org/show_bug.cgi?id=1396848

---

I've created the new build (x32, Windows) and tested.
