### PR TITLE
Remove active window styling on Win10 when no accent color is applied

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -97,36 +97,28 @@
     }
     @media (-moz-windows-accent-color-applies: 0) {
       /* Default styling for when no accent color is applied */
-      #main-window:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        background-color: hsl(235, 33%, 19%);
-      }
-      
-      :root:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        --titlebar-text-color: white;
-      }
-      
       #titlebar-min:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        list-style-image: url(chrome://browser/skin/caption-buttons.svg#minimize-highlight);
+        list-style-image: url(chrome://browser/skin/caption-buttons.svg#minimize);
       }
 
       #titlebar-max:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        list-style-image: url(chrome://browser/skin/caption-buttons.svg#maximize-highlight);
+        list-style-image: url(chrome://browser/skin/caption-buttons.svg#maximize);
       }
 
       #main-window[sizemode="maximized"] #titlebar-max:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        list-style-image: url(chrome://browser/skin/caption-buttons.svg#restore-highlight);
+        list-style-image: url(chrome://browser/skin/caption-buttons.svg#restore);
       }
       
-      #titlebar-close:not(:-moz-window-inactive):not(:-moz-lwtheme) {
-        list-style-image: url(chrome://browser/skin/caption-buttons.svg#close-highlight);
+      #titlebar-close:not(:-moz-window-inactive):not(:-moz-lwtheme):not(:hover) {
+        list-style-image: url(chrome://browser/skin/caption-buttons.svg#close);
       }
 
       .titlebar-button:not(#titlebar-close):not(:-moz-window-inactive):not(:-moz-lwtheme):hover {
-        background-color: hsla(0, 0%, 100%, .17);
+        background-color: hsla(0, 0%, 0%, .17);
       }
 
       .titlebar-button:not(#titlebar-close):not(:-moz-window-inactive):not(:-moz-lwtheme):hover:active	{
-        background-color: hsla(0, 0%, 100%, .27);
+        background-color: hsla(0, 0%, 0%, .27);
         transition: none;
       }
       
@@ -135,7 +127,7 @@
       }
 
       #titlebar-close:not(:-moz-window-inactive):not(:-moz-lwtheme):hover:active	{
-        background-color: hsla(0, 60%, 39%, 1);
+        background-color: hsla(0, 60%, 49%, 0.6);
         transition: none;
       }
     }


### PR DESCRIPTION
Port of https://github.com/MoonchildProductions/Pale-Moon/commit/ffd696dc410a921e2a21a73327e7ea79ff260764 to UXP.

This differs slightly from the Pale Moon implementation, as this provides a default style, and uses it as inactive (since we override it with the accent-color variants otherwise). This simply reverts back to the default styling when there isn't an accent color in use.