### PR TITLE
Launch command: basilisk "-migration -p" (throws an error)

### DIFF
--- a/toolkit/components/xulstore/XULStore.js
+++ b/toolkit/components/xulstore/XULStore.js
@@ -100,7 +100,7 @@ XULStore.prototype = {
     Services.console.logStringMessage("XULStore: " + message);
   },
 
-  import: function(profileType) {
+  import(profileType) {
     let localStoreFile = Services.dirsvc.get(profileType || "ProfD", Ci.nsIFile);
 
     localStoreFile.append("localstore.rdf");

--- a/toolkit/components/xulstore/XULStore.js
+++ b/toolkit/components/xulstore/XULStore.js
@@ -63,11 +63,21 @@ XULStore.prototype = {
   load() {
     Services.obs.addObserver(this, "profile-before-change", true);
 
-    this._storeFile = Services.dirsvc.get("ProfD", Ci.nsIFile);
+    let profileType = "ProfD";
+    try {
+      this._storeFile = Services.dirsvc.get(profileType, Ci.nsIFile);
+    } catch (ex) {
+      try {
+        profileType = "ProfDS";
+        this._storeFile = Services.dirsvc.get(profileType, Ci.nsIFile);
+      } catch (ex) {
+        throw new Error("Can't find profile directory.");
+      }
+    }
     this._storeFile.append(STOREDB_FILENAME);
 
     if (!this._storeFile.exists()) {
-      this.import();
+      this.import(profileType);
     } else {
       this.readFile();
     }
@@ -90,8 +100,8 @@ XULStore.prototype = {
     Services.console.logStringMessage("XULStore: " + message);
   },
 
-  import() {
-    let localStoreFile = Services.dirsvc.get("ProfD", Ci.nsIFile);
+  import: function(profileType) {
+    let localStoreFile = Services.dirsvc.get(profileType || "ProfD", Ci.nsIFile);
 
     localStoreFile.append("localstore.rdf");
     if (!localStoreFile.exists()) {


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/pull/1402

Launch command: basilisk "-migration -p" (and create a new profile)

After starting the browser, throws an error in Browser Console:

```
NS_ERROR_FAILURE: Component returned failure code:
0x80004005 (NS_ERROR_FAILURE) [nsIProperties.get]
XULStore.js:66:0

NS_ERROR_FAILURE: Component returned failure code:
0x80004005 (NS_ERROR_FAILURE) [nsIProperties.get]
XULStore.js:102:0

```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1398136
https://bugzilla.mozilla.org/show_bug.cgi?id=1368567 (partially)

---

You add the label `Verification Needed` (for original function: https://github.com/MoonchildProductions/Pale-Moon/issues/759), please.

---

I've created the new build (x32, Windows) and tested.
