### PR TITLE
Ensure propagation of MC_OFFICIAL to appini_defines

### DIFF
--- a/build/moz.build
+++ b/build/moz.build
@@ -64,6 +64,9 @@ if CONFIG['MOZ_APP_BASENAME']:
     if CONFIG['MOZ_APP_PROFILE']:
         appini_defines['MOZ_APP_PROFILE'] = CONFIG['MOZ_APP_PROFILE']
 
+    if CONFIG['MC_OFFICIAL']:
+        appini_defines['MC_OFFICIAL'] = CONFIG['MC_OFFICIAL']
+
     for var in ('MOZ_CRASHREPORTER', 'MOZ_PROFILE_MIGRATOR'):
         if CONFIG[var]:
             appini_defines[var] = True


### PR DESCRIPTION
Was there something wrong with just sending all defines to preprocessed files?!

This resolves the application.ini/appdata issues.