### PR TITLE
Notifications - user settings - the immediate duration of the alert

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4816,6 +4816,8 @@ pref("dom.webnotifications.requireinteraction.enabled", false);
 
 // Alert animation effect, name is disableSlidingEffect for backwards-compat.
 pref("alerts.disableSlidingEffect", false);
+// The immediate duration of the alert, in milliseconds.
+pref("alerts.durationImmediate", 20000);
 // Show favicons in web notifications.
 pref("alerts.showFavicons", false);
 

--- a/toolkit/components/alerts/resources/content/alert.css
+++ b/toolkit/components/alerts/resources/content/alert.css
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #alertBox[animate] {
-  animation-duration: 20s;
   animation-fill-mode: both;
   animation-name: alert-animation;
 }

--- a/toolkit/components/alerts/resources/content/alert.js
+++ b/toolkit/components/alerts/resources/content/alert.js
@@ -166,7 +166,12 @@ function prefillAlertInfo() {
 }
 
 function onAlertLoad() {
-  const ALERT_DURATION_IMMEDIATE = 20000;
+  const ALERT_DURATION_IMMEDIATE_MIN = 4000;
+  const ALERT_DURATION_IMMEDIATE_MAX = 60000;
+  let alertDurationImmediate = Services.prefs.getIntPref("alerts.durationImmediate", ALERT_DURATION_IMMEDIATE_MIN);
+  alertDurationImmediate = alertDurationImmediate >= ALERT_DURATION_IMMEDIATE_MIN
+      && alertDurationImmediate <= ALERT_DURATION_IMMEDIATE_MAX
+      ? alertDurationImmediate : ALERT_DURATION_IMMEDIATE_MIN;
   let alertTextBox = document.getElementById("alertTextBox");
   let alertImageBox = document.getElementById("alertImageBox");
   alertImageBox.style.minHeight = alertTextBox.scrollHeight + "px";
@@ -186,7 +191,7 @@ function onAlertLoad() {
   // If the require interaction flag is set, prevent auto-closing the notification.
   if (!gRequireInteraction) {
     if (Services.prefs.getBoolPref("alerts.disableSlidingEffect")) {
-      setTimeout(function() { window.close(); }, ALERT_DURATION_IMMEDIATE);
+      setTimeout(function() { window.close(); }, alertDurationImmediate);
     } else {
       let alertBox = document.getElementById("alertBox");
       alertBox.addEventListener("animationend", function hideAlert(event) {
@@ -197,6 +202,7 @@ function onAlertLoad() {
           window.close();
         }
       });
+      alertBox.style.animationDuration = Math.round(alertDurationImmediate / 1000).toString() + "s";
       alertBox.setAttribute("animate", true);
     }
   }


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/pull/1420

IMHO: Even in this case it makes sense:
`dom.webnotifications.requireinteraction.enabled` = `false`, etc.

---

I've created the new build (x32, Windows) and tested.
