### PR TITLE
If 'export BASILISK_VERSION=1' is in mozconfig then use 55.0.YYYY.MM.DD as MOZ_APP_VERSION

### DIFF
--- a/browser/confvars.sh
+++ b/browser/confvars.sh
@@ -20,9 +20,22 @@ fi
 # Enable building ./signmar and running libmar signature tests
 MOZ_ENABLE_SIGNMAR=
 
-MOZ_APP_VERSION=$FIREFOX_VERSION
+# For Basilisk we want to use 55.0.YYYY.MM.DD as MOZ_APP_VERSION in release
+# builds so add-on developers have something to target while maintaining
+# Firefox compatiblity.
+# To enable add "export BASILISK_VERSION=1" to the .mozconfig file.
+# However, this will cause a full rebuild at 00:00 UTC every day so
+# don't export the variable if you are in development or don't care.
+# When not exported we fall back the value in the version.txt file.
+if test -n "$BASILISK_VERSION" ; then
+    MOZ_APP_VERSION=55.0.`date --utc '+%Y.%m.%d'`
+else
+    MOZ_APP_VERSION=$FIREFOX_VERSION
+fi
+
 MOZ_APP_VERSION_DISPLAY=$FIREFOX_VERSION_DISPLAY
 MOZ_EXTENSIONS_DEFAULT=" gio"
+
 # MOZ_APP_DISPLAYNAME will be set by branding/configure.sh
 # MOZ_BRANDING_DIRECTORY is the default branding directory used when none is
 # specified. It should never point to the "official" branding directory.


### PR DESCRIPTION
Just what it says on the shipping label