### PR TITLE
CSP - Support frame-ancestors in Content-Security-Policy-Report-Only

### DIFF
--- a/dom/security/nsCSPContext.cpp
+++ b/dom/security/nsCSPContext.cpp
@@ -220,14 +220,6 @@ nsCSPContext::permitsInternal(CSPDirective aDir,
 
   nsAutoString violatedDirective;
   for (uint32_t p = 0; p < mPolicies.Length(); p++) {
-
-    // According to the W3C CSP spec, frame-ancestors checks are ignored for
-    // report-only policies (when "monitoring").
-    if (aDir == nsIContentSecurityPolicy::FRAME_ANCESTORS_DIRECTIVE &&
-        mPolicies[p]->getReportOnlyFlag()) {
-      continue;
-    }
-
     if (!mPolicies[p]->permits(aDir,
                                aContentLocation,
                                aNonce,

--- a/dom/security/test/csp/file_frame_ancestors_ro.html
+++ b/dom/security/test/csp/file_frame_ancestors_ro.html
@@ -1,0 +1,1 @@
+<html><body>Child Document</body></html>

--- a/dom/security/test/csp/file_frame_ancestors_ro.html^headers^
+++ b/dom/security/test/csp/file_frame_ancestors_ro.html^headers^
@@ -1,0 +1,1 @@
+Content-Security-Policy-Report-Only: frame-ancestors 'none'; report-uri http://mochi.test:8888/foo.sjs

--- a/dom/security/test/csp/mochitest.ini
+++ b/dom/security/test/csp/mochitest.ini
@@ -91,6 +91,8 @@ support-files =
   file_bug941404.html
   file_bug941404_xhr.html
   file_bug941404_xhr.html^headers^
+  file_frame_ancestors_ro.html
+  file_frame_ancestors_ro.html^headers^
   file_hash_source.html
   file_dual_header_testserver.sjs
   file_hash_source.html^headers^
@@ -239,6 +241,7 @@ skip-if = toolkit == 'android' # Times out, not sure why (bug 1008445)
 [test_bug910139.html]
 [test_bug909029.html]
 [test_bug1229639.html]
+[test_frame_ancestors_ro.html]
 [test_policyuri_regression_from_multipolicy.html]
 [test_nonce_source.html]
 [test_bug941404.html]

--- a/dom/security/test/csp/test_frame_ancestors_ro.html
+++ b/dom/security/test/csp/test_frame_ancestors_ro.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Test for frame-ancestors support in Content-Security-Policy-Report-Only</title>
+  <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
+</head>
+<body>
+<iframe style="width: 100%" id="cspframe"></iframe>
+<script type="text/javascript">
+const docUri = "http://mochi.test:8888/tests/dom/security/test/csp/file_frame_ancestors_ro.html";
+const frame = document.getElementById("cspframe");
+
+let testResults = {
+  reportFired: false,
+  frameLoaded: false
+};
+
+function checkResults(reportObj) {
+  let cspReport = reportObj["csp-report"];
+  is(cspReport["document-uri"], docUri, "Incorrect document-uri");
+
+  // we can not test for the whole referrer since it includes platform specific information
+  is(cspReport["referrer"], document.location.toString(), "Incorrect referrer");
+  is(cspReport["blocked-uri"], document.location.toString(), "Incorrect blocked-uri");
+  is(cspReport["violated-directive"], "frame-ancestors 'none'", "Incorrect violated-directive");
+  is(cspReport["original-policy"], "frame-ancestors 'none'; report-uri http://mochi.test:8888/foo.sjs", "Incorrect original-policy");
+  testResults.reportFired = true;
+}
+
+let chromeScriptUrl = SimpleTest.getTestFileURL("file_report_chromescript.js");
+let script = SpecialPowers.loadChromeScript(chromeScriptUrl);
+
+script.addMessageListener('opening-request-completed', function ml(msg) {
+  if (msg.error) {
+    ok(false, "Could not query report (exception: " + msg.error + ")");
+  } else {
+    try {
+      let reportObj = JSON.parse(msg.report);
+      // test for the proper values in the report object
+      checkResults(reportObj);
+    } catch (e) {
+      ok(false, "Error verifying report object (exception: " + e + ")");
+    }
+  }
+
+  script.removeMessageListener('opening-request-completed', ml);
+  script.sendAsyncMessage("finish");
+  checkTestResults();
+});
+
+frame.addEventListener( 'load', () => {
+  // Make sure the frame is still loaded
+  testResults.frameLoaded = true;
+  checkTestResults()
+} );
+
+function checkTestResults() {
+  if( testResults.reportFired && testResults.frameLoaded ) {
+    SimpleTest.finish();
+  }
+}
+
+SimpleTest.waitForExplicitFinish();
+frame.src = docUri;
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
> Despite what the comment here says, there is nowhere in the W3C CSP spec stating
that frame-ancestors should be ignored in report-only mode.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1380755

---

I've created the new build (x32, Windows) but __not tested__.
