### PR TITLE
[minor fix] DevTools - Throws an error ("String contains an invalid character")

### DIFF
--- a/devtools/client/netmonitor/request-utils.js
+++ b/devtools/client/netmonitor/request-utils.js
@@ -104,7 +104,7 @@ const fetchHeaders = Task.async(function* (headers, getString) {
 function formDataURI(mimeType, encoding, text) {
   if (!encoding) {
     encoding = "base64";
-    text = btoa(text);
+    text = btoa(unescape(encodeURIComponent(text)));
   }
   return "data:" + mimeType + ";" + encoding + "," + text;
 }


### PR DESCRIPTION
__Steps to reproduce__
Turn DevTools on (`Tools` - `Web Developer` - `Network`)
Go to (e.g.): https://www.seznam.cz/

Throws an error in Browser Console:
```
A promise chain failed to handle a rejection.
Did you forget to '.catch', or did you forget to 'return'?
See https://developer.mozilla.org/Mozilla/JavaScript_code_modules/Promise.jsm/Promise
Date: Wed Nov 01 2017 20:39:04 GMT+0100
Full Message: String contains an invalid character
Full Stack:
JS frame :: resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/client/netmonitor/request-utils.js
:: formDataURI :: line 107
JS frame :: resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/client/netmonitor/requests-menu-view.js
:: RequestsMenuView.prototype.updateRequest< :: line 279
JS frame :: resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/shared/task.js :: _run :: line 311
request-utils.js:107
```

See:
https://hg.mozilla.org/mozilla-central/rev/12b1474b8065#l9.13

An example (for Scratchpad):
``` javascript
var text = "™";

alert(btoa(unescape(encodeURIComponent(text))));

// alert(btoa(text));
// Exception: InvalidCharacterError: String contains an invalid character
```

---

I've created the new build (x32, Windows) and tested.
