### PR TITLE
Consider blocking top level window data: URIs (part 2)

### DIFF
--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -9868,16 +9868,6 @@ nsDocShell::InternalLoad(nsIURI* aURI,
     contentType = nsIContentPolicy::TYPE_DOCUMENT;
   }
 
-  if (!nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
-        aURI,
-        contentType,
-        aTriggeringPrincipal,
-        (aLoadType == LOAD_NORMAL_EXTERNAL),
-        !aFileName.IsVoid())) {
-    // logging to console happens within AllowTopLevelNavigationToDataURI
-    return NS_OK;
-  }
-
   // If there's no targetDocShell, that means we are about to create a new
   // window (or aWindowTarget is empty). Perform a content policy check before
   // creating the window. Please note for all other docshell loads
@@ -10983,6 +10973,7 @@ nsDocShell::DoURILoad(nsIURI* aURI,
   if (aPrincipalToInherit) {
     loadInfo->SetPrincipalToInherit(aPrincipalToInherit);
   }
+  loadInfo->SetLoadTriggeredFromExternal(aLoadFromExternal);
 
   // We have to do this in case our OriginAttributes are different from the
   // OriginAttributes of the parent document. Or in case there isn't a

--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -9872,7 +9872,8 @@ nsDocShell::InternalLoad(nsIURI* aURI,
         aURI,
         contentType,
         aTriggeringPrincipal,
-        (aLoadType == LOAD_NORMAL_EXTERNAL))) {
+        (aLoadType == LOAD_NORMAL_EXTERNAL),
+        !aFileName.IsVoid())) {
     // logging to console happens within AllowTopLevelNavigationToDataURI
     return NS_OK;
   }

--- a/dom/security/nsContentSecurityManager.cpp
+++ b/dom/security/nsContentSecurityManager.cpp
@@ -13,21 +13,16 @@
 #include "nsCDefaultURIFixup.h"
 #include "nsIURIFixup.h"
 #include "nsINestedURI.h"
-#include "nsNullPrincipal.h"
 
 #include "mozilla/dom/Element.h"
+#include "mozilla/dom/TabChild.h"
 
 NS_IMPL_ISUPPORTS(nsContentSecurityManager,
                   nsIContentSecurityManager,
                   nsIChannelEventSink)
 
 /* static */ bool
-nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
-  nsIURI* aURI,
-  nsContentPolicyType aContentPolicyType,
-  nsIPrincipal* aTriggeringPrincipal,
-  bool aLoadFromExternal,
-  bool aIsDownLoad)
+nsContentSecurityManager::AllowTopLevelNavigationToDataURI(nsIChannel* aChannel)
 {
   // Let's block all toplevel document navigations to a data: URI.
   // In all cases where the toplevel document is navigated to a
@@ -40,17 +35,24 @@ nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
   if (!mozilla::net::nsIOService::BlockToplevelDataUriNavigations()) {
     return true;
   }
-  if (aContentPolicyType != nsIContentPolicy::TYPE_DOCUMENT || aIsDownLoad) {
+  nsCOMPtr<nsILoadInfo> loadInfo = aChannel->GetLoadInfo();
+  if (!loadInfo) {
     return true;
   }
+  if (loadInfo->GetExternalContentPolicyType() != nsIContentPolicy::TYPE_DOCUMENT) {
+    return true;
+  }
+  nsCOMPtr<nsIURI> uri;
+  nsresult rv = NS_GetFinalChannelURI(aChannel, getter_AddRefs(uri));
+  NS_ENSURE_SUCCESS(rv, true);
   bool isDataURI =
-    (NS_SUCCEEDED(aURI->SchemeIs("data", &isDataURI)) && isDataURI);
+    (NS_SUCCEEDED(uri->SchemeIs("data", &isDataURI)) && isDataURI);
   if (!isDataURI) {
     return true;
   }
   // Whitelist data: images as long as they are not SVGs
   nsAutoCString filePath;
-  aURI->GetFilePath(filePath);
+  uri->GetFilePath(filePath);
   if (StringBeginsWith(filePath, NS_LITERAL_CSTRING("image/")) &&
       !StringBeginsWith(filePath, NS_LITERAL_CSTRING("image/svg+xml"))) {
     return true;
@@ -60,22 +62,29 @@ nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
       StringBeginsWith(filePath, NS_LITERAL_CSTRING("application/json"))) {
     return true;
   }
-  if (!aLoadFromExternal &&
-      nsContentUtils::IsSystemPrincipal(aTriggeringPrincipal)) {
+  // Redirecting to a toplevel data: URI is not allowed, hence we make
+  // sure the RedirectChain is empty.
+  if (!loadInfo->GetLoadTriggeredFromExternal() &&
+      nsContentUtils::IsSystemPrincipal(loadInfo->TriggeringPrincipal()) &&
+      loadInfo->RedirectChain().IsEmpty()) {
     return true;
   }
   nsAutoCString dataSpec;
-  aURI->GetSpec(dataSpec);
+  uri->GetSpec(dataSpec);
   if (dataSpec.Length() > 50) {
     dataSpec.Truncate(50);
     dataSpec.AppendLiteral("...");
+  }
+  nsCOMPtr<nsITabChild> tabChild = do_QueryInterface(loadInfo->ContextForTopLevelLoad());
+  nsCOMPtr<nsIDocument> doc;
+  if (tabChild) {
+    doc = static_cast<mozilla::dom::TabChild*>(tabChild.get())->GetDocument();
   }
   NS_ConvertUTF8toUTF16 specUTF16(NS_UnescapeURL(dataSpec));
   const char16_t* params[] = { specUTF16.get() };
   nsContentUtils::ReportToConsole(nsIScriptError::warningFlag,
                                   NS_LITERAL_CSTRING("DATA_URI_BLOCKED"),
-                                  // no doc available, log to browser console
-                                  nullptr,
+                                  doc,
                                   nsContentUtils::eSECURITY_PROPERTIES,
                                   "BlockTopLevelDataURINavigation",
                                   params, ArrayLength(params));
@@ -585,28 +594,6 @@ nsContentSecurityManager::AsyncOnChannelRedirect(nsIChannel* aOldChannel,
     if (NS_FAILED(rv)) {
       aOldChannel->Cancel(rv);
       return rv;
-    }
-  }
-
-  // Redirecting to a toplevel data: URI is not allowed, hence we pass
-  // a NullPrincipal as the TriggeringPrincipal to
-  // AllowTopLevelNavigationToDataURI() which definitely blocks any
-  // data: URI load.
-  nsCOMPtr<nsILoadInfo> newLoadInfo = aNewChannel->GetLoadInfo();
-  if (newLoadInfo) {
-    nsCOMPtr<nsIURI> uri;
-    nsresult rv = NS_GetFinalChannelURI(aNewChannel, getter_AddRefs(uri));
-    NS_ENSURE_SUCCESS(rv, rv);
-    nsCOMPtr<nsIPrincipal> nullTriggeringPrincipal = nsNullPrincipal::Create();
-    if (!nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
-          uri,
-          newLoadInfo->GetExternalContentPolicyType(),
-          nullTriggeringPrincipal,
-          false,
-          false)) {
-        // logging to console happens within AllowTopLevelNavigationToDataURI
-      aOldChannel->Cancel(NS_ERROR_DOM_BAD_URI);
-      return NS_ERROR_DOM_BAD_URI;
     }
   }
 

--- a/dom/security/nsContentSecurityManager.cpp
+++ b/dom/security/nsContentSecurityManager.cpp
@@ -26,7 +26,8 @@ nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
   nsIURI* aURI,
   nsContentPolicyType aContentPolicyType,
   nsIPrincipal* aTriggeringPrincipal,
-  bool aLoadFromExternal)
+  bool aLoadFromExternal,
+  bool aIsDownLoad)
 {
   // Let's block all toplevel document navigations to a data: URI.
   // In all cases where the toplevel document is navigated to a
@@ -39,7 +40,7 @@ nsContentSecurityManager::AllowTopLevelNavigationToDataURI(
   if (!mozilla::net::nsIOService::BlockToplevelDataUriNavigations()) {
     return true;
   }
-  if (aContentPolicyType != nsIContentPolicy::TYPE_DOCUMENT) {
+  if (aContentPolicyType != nsIContentPolicy::TYPE_DOCUMENT || aIsDownLoad) {
     return true;
   }
   bool isDataURI =
@@ -601,6 +602,7 @@ nsContentSecurityManager::AsyncOnChannelRedirect(nsIChannel* aOldChannel,
           uri,
           newLoadInfo->GetExternalContentPolicyType(),
           nullTriggeringPrincipal,
+          false,
           false)) {
         // logging to console happens within AllowTopLevelNavigationToDataURI
       aOldChannel->Cancel(NS_ERROR_DOM_BAD_URI);

--- a/dom/security/nsContentSecurityManager.h
+++ b/dom/security/nsContentSecurityManager.h
@@ -35,7 +35,9 @@ public:
   static bool AllowTopLevelNavigationToDataURI(nsIURI* aURI,
                                                nsContentPolicyType aContentPolicyType,
                                                nsIPrincipal* aTriggeringPrincipal,
-                                               bool aLoadFromExternal);
+                                               bool aLoadFromExternal,
+                                               bool aIsDownload);
+ 
 
 private:
   static nsresult CheckChannel(nsIChannel* aChannel);

--- a/dom/security/nsContentSecurityManager.h
+++ b/dom/security/nsContentSecurityManager.h
@@ -32,12 +32,7 @@ public:
   static nsresult doContentSecurityCheck(nsIChannel* aChannel,
                                          nsCOMPtr<nsIStreamListener>& aInAndOutListener);
 
-  static bool AllowTopLevelNavigationToDataURI(nsIURI* aURI,
-                                               nsContentPolicyType aContentPolicyType,
-                                               nsIPrincipal* aTriggeringPrincipal,
-                                               bool aLoadFromExternal,
-                                               bool aIsDownload);
- 
+  static bool AllowTopLevelNavigationToDataURI(nsIChannel* aChannel);
 
 private:
   static nsresult CheckChannel(nsIChannel* aChannel);

--- a/dom/security/test/general/browser.ini
+++ b/dom/security/test/general/browser.ini
@@ -3,3 +3,6 @@
 support-files =
   file_toplevel_data_navigations.sjs
   file_toplevel_data_meta_redirect.html
+[browser_test_data_download.js]
+support-files =
+  file_data_download.html

--- a/dom/security/test/general/browser.ini
+++ b/dom/security/test/general/browser.ini
@@ -6,3 +6,6 @@ support-files =
 [browser_test_data_download.js]
 support-files =
   file_data_download.html
+[browser_test_data_text_csv.js]
+support-files =
+  file_data_text_csv.html

--- a/dom/security/test/general/browser_test_data_download.js
+++ b/dom/security/test/general/browser_test_data_download.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const kTestPath = getRootDirectory(gTestPath)
+                  .replace("chrome://mochitests/content", "http://example.com")
+const kTestURI = kTestPath + "file_data_download.html";
+
+function addWindowListener(aURL, aCallback) {
+  Services.wm.addListener({
+    onOpenWindow(aXULWindow) {
+      info("window opened, waiting for focus");
+      Services.wm.removeListener(this);
+      var domwindow = aXULWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                                .getInterface(Ci.nsIDOMWindow);
+      waitForFocus(function() {
+        is(domwindow.document.location.href, aURL, "should have seen the right window open");
+        aCallback(domwindow);
+      }, domwindow);
+    },
+    onCloseWindow(aXULWindow) { },
+    onWindowTitleChange(aXULWindow, aNewTitle) { }
+  });
+}
+
+function test() {
+  waitForExplicitFinish();
+  Services.prefs.setBoolPref("security.data_uri.block_toplevel_data_uri_navigations", true);
+  registerCleanupFunction(function() {
+    Services.prefs.clearUserPref("security.data_uri.block_toplevel_data_uri_navigations");
+  });
+  addWindowListener("chrome://mozapps/content/downloads/unknownContentType.xul", function(win) {
+    is(win.document.getElementById("location").value, "data-foo.html",
+       "file name of download should match");
+     win.close();
+     finish();
+  });
+  gBrowser.loadURI(kTestURI);
+}

--- a/dom/security/test/general/browser_test_data_text_csv.js
+++ b/dom/security/test/general/browser_test_data_text_csv.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const kTestPath = getRootDirectory(gTestPath)
+                  .replace("chrome://mochitests/content", "http://example.com")
+const kTestURI = kTestPath + "file_data_text_csv.html";
+
+function addWindowListener(aURL, aCallback) {
+  Services.wm.addListener({
+    onOpenWindow(aXULWindow) {
+      info("window opened, waiting for focus");
+      Services.wm.removeListener(this);
+      var domwindow = aXULWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                                .getInterface(Ci.nsIDOMWindow);
+      waitForFocus(function() {
+        is(domwindow.document.location.href, aURL, "should have seen the right window open");
+        aCallback(domwindow);
+      }, domwindow);
+    },
+    onCloseWindow(aXULWindow) { },
+    onWindowTitleChange(aXULWindow, aNewTitle) { }
+  });
+}
+
+function test() {
+  waitForExplicitFinish();
+  Services.prefs.setBoolPref("security.data_uri.block_toplevel_data_uri_navigations", true);
+  registerCleanupFunction(function() {
+    Services.prefs.clearUserPref("security.data_uri.block_toplevel_data_uri_navigations");
+  });
+  addWindowListener("chrome://mozapps/content/downloads/unknownContentType.xul", function(win) {
+    is(win.document.getElementById("location").value, "text/csv;foo,bar,foobar",
+       "file name of download should match");
+     win.close();
+     finish();
+  });
+  gBrowser.loadURI(kTestURI);
+}

--- a/dom/security/test/general/file_data_download.html
+++ b/dom/security/test/general/file_data_download.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Test download attribute for data: URI</title>
+</head>
+<body>
+  <a href="data:text/html,<body>data download</body>" download="data-foo.html" id="testlink">download data</a>
+  <script>
+    // click the link to have the downoad panel appear
+    let testlink = document.getElementById("testlink");
+    testlink.click();
+  </script>
+  </body>
+</html>

--- a/dom/security/test/general/file_data_text_csv.html
+++ b/dom/security/test/general/file_data_text_csv.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Test open data:text/csv</title>
+</head>
+<body>
+  <a href="data:text/csv;foo,bar,foobar" id="testlink">test text/csv</a>
+  <script>
+    // click the link to have the downoad panel appear
+    let testlink = document.getElementById("testlink");
+    testlink.click();
+  </script>
+  </body>
+</html>

--- a/dom/security/test/general/test_block_toplevel_data_img_navigation.html
+++ b/dom/security/test/general/test_block_toplevel_data_img_navigation.html
@@ -34,15 +34,17 @@ function test_toplevel_data_image_svg() {
   const DATA_SVG =
     "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICA8cGF0aCBkPSJNOCwxMkwzLDcsNCw2bDQsNCw0LTQsMSwxWiIgZmlsbD0iIzZBNkE2QSIgLz4KPC9zdmc+Cg==";
   let win2 = window.open(DATA_SVG);
-  let wrappedWin2 = SpecialPowers.wrap(win2);
-  setTimeout(function () {
-    isnot(wrappedWin2.document.documentElement.localName, "svg",
-          "Loading data:image/svg+xml should be blocked");
-    wrappedWin2.close();
-    SimpleTest.finish();
-  }, 1000);
+  // Unfortunately we can't detect whether the window was closed using some event,
+  // hence we are constantly polling till we see that win == null.
+  // Test times out on failure.
+  var win2Closed = setInterval(function() {
+    if (win2 == null || win2.closed) {
+      clearInterval(win2Closed);
+      ok(true, "Loading data:image/svg+xml should be blocked");
+      SimpleTest.finish();
+    }
+  }, 200);
 }
-
 // fire up the tests
 test_toplevel_data_image();
 

--- a/dom/security/test/general/test_block_toplevel_data_navigation.html
+++ b/dom/security/test/general/test_block_toplevel_data_navigation.html
@@ -21,16 +21,12 @@ function test1() {
   // simple data: URI click navigation should be prevented
   let TEST_FILE = "file_block_toplevel_data_navigation.html";
   let win1 = window.open(TEST_FILE);
-  var readyStateCheckInterval = setInterval(function() {
-    let state = win1.document.readyState;
-    if (state === "interactive" || state === "complete") {
-      clearInterval(readyStateCheckInterval);
-      ok(win1.document.body.innerHTML.indexOf("test1:") !== -1,
-         "toplevel data: URI navigation through click() should be blocked");
-      win1.close();
-      test2();
-    }
-  }, 200);
+  setTimeout(function () {
+    ok(SpecialPowers.wrap(win1).document.body.innerHTML.indexOf("test1:") !== -1,
+      "toplevel data: URI navigation through click() should be blocked");
+    win1.close();
+    test2();
+  }, 1000);
 }
 
 function test2() {

--- a/ipc/glue/BackgroundUtils.cpp
+++ b/ipc/glue/BackgroundUtils.cpp
@@ -328,6 +328,7 @@ LoadInfoToLoadInfoArgs(nsILoadInfo *aLoadInfo,
       aLoadInfo->CorsUnsafeHeaders(),
       aLoadInfo->GetForcePreflight(),
       aLoadInfo->GetIsPreflight(),
+      aLoadInfo->GetLoadTriggeredFromExternal(),
       aLoadInfo->GetForceHSTSPriming(),
       aLoadInfo->GetMixedContentWouldBlock());
 
@@ -404,6 +405,7 @@ LoadInfoArgsToLoadInfo(const OptionalLoadInfoArgs& aOptionalLoadInfoArgs,
                           loadInfoArgs.corsUnsafeHeaders(),
                           loadInfoArgs.forcePreflight(),
                           loadInfoArgs.isPreflight(),
+                          loadInfoArgs.loadTriggeredFromExternal(),
                           loadInfoArgs.forceHSTSPriming(),
                           loadInfoArgs.mixedContentWouldBlock()
                           );

--- a/netwerk/base/LoadInfo.cpp
+++ b/netwerk/base/LoadInfo.cpp
@@ -7,6 +7,7 @@
 #include "mozilla/LoadInfo.h"
 
 #include "mozilla/Assertions.h"
+#include "mozilla/dom/TabChild.h"
 #include "mozilla/dom/ToJSValue.h"
 #include "mozIThirdPartyUtil.h"
 #include "nsFrameLoader.h"
@@ -63,6 +64,7 @@ LoadInfo::LoadInfo(nsIPrincipal* aLoadingPrincipal,
   , mIsThirdPartyContext(false)
   , mForcePreflight(false)
   , mIsPreflight(false)
+  , mLoadTriggeredFromExternal(false)
   , mForceHSTSPriming(false)
   , mMixedContentWouldBlock(false)
 {
@@ -238,6 +240,7 @@ LoadInfo::LoadInfo(nsPIDOMWindowOuter* aOuterWindow,
   , mIsThirdPartyContext(false) // NB: TYPE_DOCUMENT implies not third-party.
   , mForcePreflight(false)
   , mIsPreflight(false)
+  , mLoadTriggeredFromExternal(false)
   , mForceHSTSPriming(false)
   , mMixedContentWouldBlock(false)
 {
@@ -302,6 +305,7 @@ LoadInfo::LoadInfo(const LoadInfo& rhs)
   , mCorsUnsafeHeaders(rhs.mCorsUnsafeHeaders)
   , mForcePreflight(rhs.mForcePreflight)
   , mIsPreflight(rhs.mIsPreflight)
+  , mLoadTriggeredFromExternal(rhs.mLoadTriggeredFromExternal)
   , mForceHSTSPriming(rhs.mForceHSTSPriming)
   , mMixedContentWouldBlock(rhs.mMixedContentWouldBlock)
 {
@@ -330,6 +334,7 @@ LoadInfo::LoadInfo(nsIPrincipal* aLoadingPrincipal,
                    const nsTArray<nsCString>& aCorsUnsafeHeaders,
                    bool aForcePreflight,
                    bool aIsPreflight,
+                   bool aLoadTriggeredFromExternal,
                    bool aForceHSTSPriming,
                    bool aMixedContentWouldBlock)
   : mLoadingPrincipal(aLoadingPrincipal)
@@ -353,6 +358,7 @@ LoadInfo::LoadInfo(nsIPrincipal* aLoadingPrincipal,
   , mCorsUnsafeHeaders(aCorsUnsafeHeaders)
   , mForcePreflight(aForcePreflight)
   , mIsPreflight(aIsPreflight)
+  , mLoadTriggeredFromExternal(aLoadTriggeredFromExternal)
   , mForceHSTSPriming (aForceHSTSPriming)
   , mMixedContentWouldBlock(aMixedContentWouldBlock)
 {
@@ -885,6 +891,23 @@ NS_IMETHODIMP
 LoadInfo::GetIsPreflight(bool* aIsPreflight)
 {
   *aIsPreflight = mIsPreflight;
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+LoadInfo::SetLoadTriggeredFromExternal(bool aLoadTriggeredFromExternal)
+{
+  MOZ_ASSERT(!aLoadTriggeredFromExternal ||
+             mInternalContentPolicyType == nsIContentPolicy::TYPE_DOCUMENT,
+             "can only set load triggered from external for TYPE_DOCUMENT");
+  mLoadTriggeredFromExternal = aLoadTriggeredFromExternal;
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+LoadInfo::GetLoadTriggeredFromExternal(bool* aLoadTriggeredFromExternal)
+{
+  *aLoadTriggeredFromExternal = mLoadTriggeredFromExternal;
   return NS_OK;
 }
 

--- a/netwerk/base/LoadInfo.h
+++ b/netwerk/base/LoadInfo.h
@@ -105,6 +105,7 @@ private:
            const nsTArray<nsCString>& aUnsafeHeaders,
            bool aForcePreflight,
            bool aIsPreflight,
+           bool aLoadTriggeredFromExternal,
            bool aForceHSTSPriming,
            bool aMixedContentWouldBlock);
   LoadInfo(const LoadInfo& rhs);
@@ -150,6 +151,7 @@ private:
   nsTArray<nsCString>              mCorsUnsafeHeaders;
   bool                             mForcePreflight;
   bool                             mIsPreflight;
+  bool                             mLoadTriggeredFromExternal;
 
   bool                             mForceHSTSPriming : 1;
   bool                             mMixedContentWouldBlock : 1;

--- a/netwerk/base/nsILoadInfo.idl
+++ b/netwerk/base/nsILoadInfo.idl
@@ -602,6 +602,13 @@ interface nsILoadInfo : nsISupports
   [infallible] attribute boolean initialSecurityCheckDone;
 
   /**
+   * Returns true if the load was triggered from an external application
+   * (e.g. Thunderbird). Please note that this flag will only ever be true
+   * if the load is of TYPE_DOCUMENT. 
+   */
+  [infallible] attribute boolean loadTriggeredFromExternal;
+
+  /**
    * Whenever a channel gets redirected, append the principal of the
    * channel [before the channels got redirected] to the loadinfo,
    * so that at every point this array lets us reason about all the

--- a/netwerk/ipc/NeckoChannelParams.ipdlh
+++ b/netwerk/ipc/NeckoChannelParams.ipdlh
@@ -54,6 +54,7 @@ struct LoadInfoArgs
   nsCString[]           corsUnsafeHeaders;
   bool                  forcePreflight;
   bool                  isPreflight;
+  bool                  loadTriggeredFromExternal;
   bool                  forceHSTSPriming;
   bool                  mixedContentWouldBlock;
 };


### PR DESCRIPTION
Ad:
https://github.com/MoonchildProductions/Pale-Moon/issues/1528

Ad PRs:
#223

---

`security.data_uri.block_toplevel_data_uri_navigations` = `true`

## 1) Download behaviour for data: URL

__Steps to reproduce:__

Go http://danml.com/download.html#TestUsages
Click the "text dataURL" button
(also visible in the download button on https://makecode.microbit.org)

__Actual results:__
Nothing

__Expected results:__
A save file dialog should appear

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1403641

---

## 2) Block toplevel data: URI navigations only if openend in the browser \[follow up 1)\]

__Steps to reproduce:__

Open Browser Console and write simple one liner which should create CSV file:

```
window.open('data:text/csv;base64,' + btoa(unescape(encodeURIComponent('my text;with;values'))));
```

__Actual results:__
It opens empty blocked page


__Expected results:__
It should save file

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1403814

---

__You add the label `Incomplete`, please.__

---

What else remains to do:

[META]:
https://bugzilla.mozilla.org/show_bug.cgi?id=1380959

Bugs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1407891

Tests:
https://bugzilla.mozilla.org/show_bug.cgi?id=1397651
https://bugzilla.mozilla.org/show_bug.cgi?id=1397652
https://bugzilla.mozilla.org/show_bug.cgi?id=1397653
https://bugzilla.mozilla.org/show_bug.cgi?id=1397655
https://bugzilla.mozilla.org/show_bug.cgi?id=1397656
https://bugzilla.mozilla.org/show_bug.cgi?id=1397657
https://bugzilla.mozilla.org/show_bug.cgi?id=1398574
https://bugzilla.mozilla.org/show_bug.cgi?id=1399074
https://bugzilla.mozilla.org/show_bug.cgi?id=1399468
https://bugzilla.mozilla.org/show_bug.cgi?id=1399848
https://bugzilla.mozilla.org/show_bug.cgi?id=1400347
https://bugzilla.mozilla.org/show_bug.cgi?id=1400473

---

I've created the new build (x32, Windows) and tested.
