### PR TITLE
[suggestion] WebExtensions - gecko vs. goanna (tests)

### DIFF
--- a/addon-sdk/source/test/addons/embedded-webextension/webextension/manifest.json
+++ b/addon-sdk/source/test/addons/embedded-webextension/webextension/manifest.json
@@ -3,7 +3,7 @@
   "description": "",
   "version": "0.1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "embedded-webextension@jetpack"
     }
   },

--- a/browser/base/content/test/general/browser_webext_update.json
+++ b/browser/base/content/test/general/browser_webext_update.json
@@ -6,7 +6,7 @@
           "version": "2.0",
           "update_link": "https://example.com/browser/browser/base/content/test/general/browser_webext_update2.xpi",
           "applications": {
-            "goanna": {
+            "gecko": {
               "strict_min_version": "1",
               "advisory_max_version": "55.0"
             }

--- a/devtools/client/aboutdebugging/test/addons/test-devtools-webextension-nobg/manifest.json
+++ b/devtools/client/aboutdebugging/test/addons/test-devtools-webextension-nobg/manifest.json
@@ -3,7 +3,7 @@
   "name": "test-devtools-webextension-nobg",
   "version": "1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-devtools-webextension-nobg@mozilla.org"
     }
   }

--- a/devtools/client/aboutdebugging/test/addons/test-devtools-webextension/manifest.json
+++ b/devtools/client/aboutdebugging/test/addons/test-devtools-webextension/manifest.json
@@ -3,7 +3,7 @@
   "name": "test-devtools-webextension",
   "version": "1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-devtools-webextension@mozilla.org"
     }
   },

--- a/devtools/client/aboutdebugging/test/browser_addons_reload.js
+++ b/devtools/client/aboutdebugging/test/browser_addons_reload.js
@@ -148,7 +148,7 @@ add_task(function* reloadButtonRefreshesMetadata() {
     "name": "Temporary web extension",
     "version": "1.0",
     "applications": {
-      "goanna": {
+      "gecko": {
         "id": ADDON_ID
       }
     }

--- a/devtools/client/debugger/test/mochitest/addon-source/browser_dbg_addon_webext_contentscript/manifest.json
+++ b/devtools/client/debugger/test/mochitest/addon-source/browser_dbg_addon_webext_contentscript/manifest.json
@@ -4,7 +4,7 @@
   "description": "test content script sources",
   "version": "0.1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-contentscript-sources@mozilla.com"
     }
   },

--- a/devtools/server/tests/unit/addons/web-extension-upgrade/manifest.json
+++ b/devtools/server/tests/unit/addons/web-extension-upgrade/manifest.json
@@ -3,7 +3,7 @@
   "name": "Test Addons Actor Upgrade",
   "version": "1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-addons-actor@mozilla.org"
     }
   }

--- a/devtools/server/tests/unit/addons/web-extension/manifest.json
+++ b/devtools/server/tests/unit/addons/web-extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Test Addons Actor",
   "version": "1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-addons-actor@mozilla.org"
     }
   }

--- a/devtools/server/tests/unit/addons/web-extension2/manifest.json
+++ b/devtools/server/tests/unit/addons/web-extension2/manifest.json
@@ -3,7 +3,7 @@
   "name": "Test Addons Actor 2",
   "version": "1.0",
   "applications": {
-    "goanna": {
+    "gecko": {
       "id": "test-addons-actor2@mozilla.org"
     }
   }

--- a/mobile/android/components/extensions/test/mochitest/test_ext_pageAction.html
+++ b/mobile/android/components/extensions/test/mochitest/test_ext_pageAction.html
@@ -61,7 +61,7 @@ add_task(function* test_pageAction() {
         },
       },
       "applications": {
-        "goanna": {
+        "gecko": {
           "id": "foo@bar.com",
         },
       },


### PR DESCRIPTION
Ad #232 (also - but this is not a solution to the problem)

`manifest.json`: applications.`gecko`
vs.
`manifest.json`: applications.`goanna`

See:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications

See also:
http://xref.palemoon.org/moebius-trunk/search?string=applications.gecko
applications.`goanna` - cannot currently be used

---

I've created the new build (x32, Windows), but __not tested__.
