### PR TITLE
XPCOM: exportFunction() - Fix wrong .length attribute

### DIFF
--- a/js/xpconnect/src/ExportHelpers.cpp
+++ b/js/xpconnect/src/ExportHelpers.cpp
@@ -333,11 +333,20 @@ NewFunctionForwarder(JSContext* cx, HandleId idArg, HandleObject callable,
     if (id == JSID_VOIDHANDLE)
         id = GetJSIDByIndex(cx, XPCJSContext::IDX_EMPTYSTRING);
 
+    // If our callable is a (possibly wrapped) function, we can give
+    // the exported thing the right number of args.
+    unsigned nargs = 0;
+    RootedObject unwrapped(cx, js::UncheckedUnwrap(callable));
+    if (unwrapped) {
+        if (JSFunction* fun = JS_GetObjectFunction(unwrapped))
+            nargs = JS_GetFunctionArity(fun);
+    }
+
     // We have no way of knowing whether the underlying function wants to be a
     // constructor or not, so we just mark all forwarders as constructors, and
     // let the underlying function throw for construct calls if it wants.
     JSFunction* fun = js::NewFunctionByIdWithReserved(cx, FunctionForwarder,
-                                                      0, JSFUN_CONSTRUCTOR, id);
+                                                      nargs, JSFUN_CONSTRUCTOR, id);
     if (!fun)
         return false;
 

--- a/js/xpconnect/tests/unit/test_exportFunction.js
+++ b/js/xpconnect/tests/unit/test_exportFunction.js
@@ -10,12 +10,14 @@ function run_test() {
   epsb.do_check_true = do_check_true;
   epsb.do_check_eq = do_check_eq;
   subsb.do_check_true = do_check_true;
+  subsb.do_check_eq = do_check_eq;
 
   // Exporting should work if prinicipal of the source sandbox
   // subsumes the principal of the target sandbox.
   Cu.evalInSandbox("(" + function() {
     var wasCalled = false;
     this.funToExport = function(expectedThis, a, obj, native, mixed, callback) {
+      do_check_eq(arguments.callee.length, 6);
       do_check_eq(a, 42);
       do_check_eq(obj, subsb.tobecloned);
       do_check_eq(obj.cloned, "cloned");
@@ -53,6 +55,7 @@ function run_test() {
     invokedCallback = false;
     callback = function() { invokedCallback = true; };
     imported(this, 42, tobecloned, native, mixed, callback);
+    do_check_eq(imported.length, 6);
     do_check_true(invokedCallback);
   }.toSource() + ")()", subsb);
 


### PR DESCRIPTION
This PR gives functions created via `exportFunction()` the same `.length()` as the function being exported.
This resolves #242.

Based on:
https://bugzilla.mozilla.org/show_bug.cgi?id=1081385