### PR TITLE
basilisk -jsdebugger - Import Console.jsm before calling console.[something]

### DIFF
--- a/devtools/client/devtools-startup.js
+++ b/devtools/client/devtools-startup.js
@@ -104,12 +104,14 @@ DevToolsStartup.prototype = {
         return Services.prefs.getBoolPref(pref);
       });
     } catch (ex) {
+      let { console } = Cu.import("resource://gre/modules/Console.jsm", {});
       console.error(ex);
       return false;
     }
     if (!remoteDebuggingEnabled) {
       let errorMsg = "Could not run chrome debugger! You need the following " +
                      "prefs to be set to true: " + kDebuggerPrefs.join(", ");
+      let { console } = Cu.import("resource://gre/modules/Console.jsm", {});
       console.error(new Error(errorMsg));
       // Dump as well, as we're doing this from a commandline, make sure people
       // don't miss it:


### PR DESCRIPTION
This resolves #249 (you add the label `Devtools`, please.)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1338681

---

I've created the new build (x32, Windows) and tested.
