### PR TITLE
Add ID from a signature if it isn't included in manifest.json

### DIFF
--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -1758,9 +1758,8 @@ function shouldVerifySignedState(aAddon) {
   if (aAddon._installLocation.name == KEY_APP_SYSTEM_DEFAULTS)
     return false;
 
-  // Otherwise only check signatures if signing is enabled and the add-on is one
-  // of the signed types.
-  return ADDON_SIGNING && SIGNED_TYPES.has(aAddon.type);
+  // Otherwise only check signatures if the add-on is one of the signed types.
+  return SIGNED_TYPES.has(aAddon.type);
 }
 
 let gCertDB = Cc["@mozilla.org/security/x509certdb;1"]


### PR DESCRIPTION
This resolves #238

---

I've created the new build (x32, Windows) and tested.
