### PR TITLE
Get IDs for ID-less WebExtensions without breaking normal libJAR signature checking

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.js
+++ b/toolkit/mozapps/extensions/content/extensions.js
@@ -3276,6 +3276,15 @@ var gDetailView = {
           [this._addon.name, gStrings.brandShortName, gStrings.appVersion], 3
         );
         document.getElementById("detail-warning-link").hidden = true;
+      } else if (!isCorrectlySigned(this._addon)) {
+        this.node.setAttribute("notification", "warning");
+        document.getElementById("detail-warning").textContent = gStrings.ext.formatStringFromName(
+          "details.notification.unsigned", [this._addon.name, gStrings.brandShortName], 2
+        );
+        var warningLink = document.getElementById("detail-warning-link");
+        warningLink.value = gStrings.ext.GetStringFromName("details.notification.unsigned.link");
+        warningLink.href = Services.urlFormatter.formatURLPref("app.support.baseURL") + "unsigned-addons";
+        warningLink.hidden = false;
       } else if (this._addon.blocklistState == Ci.nsIBlocklistService.STATE_SOFTBLOCKED) {
         this.node.setAttribute("notification", "warning");
         document.getElementById("detail-warning").textContent = gStrings.ext.formatStringFromName(

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1255,6 +1255,14 @@
               );
               this._warningLink.hidden = true;
               this._warningBtn.hidden = true;
+            } else if (!isUpgrade && !isCorrectlySigned(this.mAddon)) {
+              this.setAttribute("notification", "warning");
+              this._warning.textContent = gStrings.ext.formatStringFromName(
+                "notification.unsigned", [this.mAddon.name, gStrings.brandShortName], 2
+              );
+              this._warningLink.value = gStrings.ext.GetStringFromName("notification.unsigned.link");
+              this._warningLink.href = Services.urlFormatter.formatURLPref("app.support.baseURL") + "unsigned-addons";
+              this._warningLink.hidden = false;
             } else if (!isUpgrade && this.mAddon.blocklistState == Ci.nsIBlocklistService.STATE_SOFTBLOCKED) {
               this.setAttribute("notification", "warning");
               this._warning.textContent = gStrings.ext.formatStringFromName(

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -1758,8 +1758,9 @@ function shouldVerifySignedState(aAddon) {
   if (aAddon._installLocation.name == KEY_APP_SYSTEM_DEFAULTS)
     return false;
 
-  // Otherwise only check signatures if the add-on is one of the signed types.
-  return SIGNED_TYPES.has(aAddon.type);
+  // Otherwise only check signatures if signing is enabled and the add-on is one
+  // of the signed types.
+  return ADDON_SIGNING && SIGNED_TYPES.has(aAddon.type);
 }
 
 let gCertDB = Cc["@mozilla.org/security/x509certdb;1"]

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -1359,6 +1359,25 @@ function generateTemporaryInstallID(aFile) {
   return id;
 }
 
+function getInstallID(aFile) {
+  const re = /\x06\x03U\x04\x03\x14[\s\S](\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}|[a-z0-9-\._]*\@[a-z0-9-\._]+)0\x82\x02"0\r\x06\t/i;
+  let result, is = {close() {}}, sis = {close() {}};
+  let uri = getURIForResourceInFile(aFile, "META-INF/mozilla.rsa");
+  try {
+    is = Services.io.newChannelFromURIWithLoadInfo(uri, null).open();
+    sis = Cc["@mozilla.org/scriptableinputstream;1"].createInstance(Ci.nsIScriptableInputStream);
+    sis.init(is);
+    let str = sis.readBytes(sis.available());
+    let match = str.match(re); 
+    if (match) {
+      result = match[1];
+    }
+  } catch(ex) {}
+  sis.close(); is.close();
+  logger.info(`Got id ${result} for ${aFile.path}`);
+  return result;
+}
+
 /**
  * Loads an AddonInternal object from an add-on extracted in a directory.
  *
@@ -1529,8 +1548,12 @@ var loadManifestFromZipReader = Task.async(function*(aZipReader, aInstallLocatio
         throw new Error(`Webextension is signed with an invalid id (${addon.id})`);
       }
     }
-    if (!addon.id && aInstallLocation == TemporaryInstallLocation) {
-      addon.id = generateTemporaryInstallID(aZipReader.file);
+    if (!addon.id) {
+      if (aInstallLocation == TemporaryInstallLocation) {
+        addon.id = generateTemporaryInstallID(aZipReader.file);
+      } else if (!ADDON_SIGNING) {
+        addon.id = getInstallID(aZipReader.file);
+      }
     }
   }
   addon.appDisabled = !isUsableAddon(addon);


### PR DESCRIPTION
* Revert [WebExtensions - adding ID from an sign, if it isn't in manifest.json](https://github.com/MoonchildProductions/moebius/commit/7ede45b5f546363ab297c66601d96252c072d36d)
* Revert [Remove warning for "unsigned" extensions.](https://github.com/MoonchildProductions/moebius/commit/25384fde4edec1a003347fa4dc7d17436a003fa7)
* Get IDs for ID-less WebExtensions when verification against Mozilla's hard-coded CA is disabled

This resolves #277.