### PR TITLE
Undeprecate viewSource.xul's original/legacy API

### DIFF
--- a/toolkit/components/viewsource/content/viewSource-content.js
+++ b/toolkit/components/viewsource/content/viewSource-content.js
@@ -43,7 +43,7 @@ var ViewSourceContent = {
    */
   messages: [
     "ViewSource:LoadSource",
-    "ViewSource:LoadSourceDeprecated",
+    "ViewSource:LoadSourceLegacy",
     "ViewSource:LoadSourceWithSelection",
     "ViewSource:GoToLine",
     "ViewSource:ToggleWrapping",
@@ -131,8 +131,8 @@ var ViewSourceContent = {
         this.viewSource(data.URL, data.outerWindowID, data.lineNumber,
                         data.shouldWrap);
         break;
-      case "ViewSource:LoadSourceDeprecated":
-        this.viewSourceDeprecated(data.URL, objects.pageDescriptor, data.lineNumber,
+      case "ViewSource:LoadSourceLegacy":
+        this.viewSourceLegacy(data.URL, objects.pageDescriptor, data.lineNumber,
                                   data.forcedCharSet);
         break;
       case "ViewSource:LoadSourceWithSelection":
@@ -245,7 +245,7 @@ var ViewSourceContent = {
   },
 
   /**
-   * Called when the parent is using the deprecated API for viewSource.xul.
+   * Called when the parent is using the legacy API for viewSource.xul.
    * This function will throw if it's called on a remote browser.
    *
    * @param URL (required)
@@ -260,11 +260,11 @@ var ViewSourceContent = {
    * @param forcedCharSet (optional)
    *        The document character set to use instead of the default one.
    */
-  viewSourceDeprecated(URL, pageDescriptor, lineNumber, forcedCharSet) {
+  viewSourceLegacy(URL, pageDescriptor, lineNumber, forcedCharSet) {
     // This should not be called if this frame script is running
     // in a content process!
     if (Services.appinfo.processType != Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      throw new Error("ViewSource deprecated API should not be used with " +
+      throw new Error("ViewSource legacy API should not be used with " +
                       "remote browsers.");
     }
 
@@ -272,7 +272,7 @@ var ViewSourceContent = {
   },
 
   /**
-   * Common utility function used by both the current and deprecated APIs
+   * Common utility function used by both the current and legacy APIs
    * for loading source.
    *
    * @param URL (required)

--- a/toolkit/components/viewsource/content/viewSource.js
+++ b/toolkit/components/viewsource/content/viewSource.js
@@ -13,8 +13,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "Services",
   "resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "CharsetMenu",
   "resource://gre/modules/CharsetMenu.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "Deprecated",
-  "resource://gre/modules/Deprecated.jsm");
 
 [
   ["gBrowser",          "content"],
@@ -260,7 +258,7 @@ ViewSourceChrome.prototype = {
    *   lineNumber (optional):
    *     The line number to focus on once the source is loaded.
    *
-   * The deprecated API has the opener pass in a number of arguments:
+   * The Legacy API has the opener pass in a number of arguments:
    *
    * arg[0] - URL string.
    * arg[1] - Charset value string in the form 'charset=xxx'.
@@ -305,8 +303,8 @@ ViewSourceChrome.prototype = {
     }
 
     if (typeof window.arguments[0] == "string") {
-      // We're using the deprecated API
-      return this._loadViewSourceDeprecated(window.arguments);
+      // We're using the legacy API
+      return this._loadViewSourceLegacy(window.arguments);
     }
 
     // We're using the modern API, which allows us to view the
@@ -322,13 +320,9 @@ ViewSourceChrome.prototype = {
   },
 
   /**
-   * This is the deprecated API for viewSource.xul, for old-timer consumers.
-   * This API might eventually go away.
+   * This is the Legacy API for viewSource.xul, for old-timer consumers.
    */
-  _loadViewSourceDeprecated(aArguments) {
-    Deprecated.warning("The arguments you're passing to viewSource.xul " +
-                       "are using an out-of-date API.",
-                       "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
+  _loadViewSourceLegacy(aArguments) {
     // Parse the 'arguments' supplied with the dialog.
     //    arg[0] - URL string.
     //    arg[1] - Charset value in the form 'charset=xxx'.
@@ -344,7 +338,7 @@ ViewSourceChrome.prototype = {
     }
 
     if (this.browser.isRemoteBrowser) {
-      throw new Error("Deprecated view source API should not use a remote browser.");
+      throw new Error("Legacy view source API should not use a remote browser.");
     }
 
     let forcedCharSet;
@@ -352,7 +346,7 @@ ViewSourceChrome.prototype = {
       forcedCharSet = aArguments[1].split("=")[1];
     }
 
-    this.sendAsyncMessage("ViewSource:LoadSourceDeprecated", {
+    this.sendAsyncMessage("ViewSource:LoadSourceLegacy", {
       URL: aArguments[0],
       lineNumber: aArguments[3],
       forcedCharSet,
@@ -791,48 +785,30 @@ function ViewSourceSavePage() {
                gPageLoader);
 }
 
-// Below are old deprecated functions and variables left behind for
-// compatibility reasons. These will be removed soon via bug 1159293.
+// Below are legacy functions and variables left behind for
+// compatibility reasons.
 
 this.__defineGetter__("gLastLineFound", function() {
-  Deprecated.warning("gLastLineFound is deprecated - please use " +
-                     "viewSourceChrome.lastLineFound instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   return viewSourceChrome.lastLineFound;
 });
 
 function onLoadViewSource() {
-  Deprecated.warning("onLoadViewSource() is deprecated - please use " +
-                     "viewSourceChrome.onXULLoaded() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.onXULLoaded();
 }
 
 function isHistoryEnabled() {
-  Deprecated.warning("isHistoryEnabled() is deprecated - please use " +
-                     "viewSourceChrome.historyEnabled instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   return viewSourceChrome.historyEnabled;
 }
 
 function ViewSourceClose() {
-  Deprecated.warning("ViewSourceClose() is deprecated - please use " +
-                     "viewSourceChrome.close() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.close();
 }
 
 function ViewSourceReload() {
-  Deprecated.warning("ViewSourceReload() is deprecated - please use " +
-                     "viewSourceChrome.reload() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.reload();
 }
 
 function getWebNavigation() {
-  Deprecated.warning("getWebNavigation() is deprecated - please use " +
-                     "viewSourceChrome.webNav instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   // The original implementation returned null if anything threw during
   // the getting of the webNavigation.
   try {
@@ -843,43 +819,25 @@ function getWebNavigation() {
 }
 
 function viewSource(url) {
-  Deprecated.warning("viewSource() is deprecated - please use " +
-                     "viewSourceChrome.loadURL() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.loadURL(url);
 }
 
 function ViewSourceGoToLine() {
-  Deprecated.warning("ViewSourceGoToLine() is deprecated - please use " +
-                     "viewSourceChrome.promptAndGoToLine() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.promptAndGoToLine();
 }
 
 function goToLine(line) {
-  Deprecated.warning("goToLine() is deprecated - please use " +
-                     "viewSourceChrome.goToLine() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.goToLine(line);
 }
 
 function BrowserForward(aEvent) {
-  Deprecated.warning("BrowserForward() is deprecated - please use " +
-                     "viewSourceChrome.goForward() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.goForward();
 }
 
 function BrowserBack(aEvent) {
-  Deprecated.warning("BrowserBack() is deprecated - please use " +
-                     "viewSourceChrome.goBack() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.goBack();
 }
 
 function UpdateBackForwardCommands() {
-  Deprecated.warning("UpdateBackForwardCommands() is deprecated - please use " +
-                     "viewSourceChrome.updateCommands() instead.",
-                     "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/View_Source_for_XUL_Applications");
   viewSourceChrome.updateCommands();
 }

--- a/toolkit/components/viewsource/content/viewSourceUtils.js
+++ b/toolkit/components/viewsource/content/viewSourceUtils.js
@@ -15,8 +15,6 @@
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ViewSourceBrowser",
   "resource://gre/modules/ViewSourceBrowser.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "Deprecated",
-  "resource://gre/modules/Deprecated.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
   "resource://gre/modules/PrivateBrowsingUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
@@ -228,10 +226,6 @@ var gViewSourceUtils = {
                                  aLineNumber, aCallBack) {
     let data;
     if (typeof aArgsOrURL == "string") {
-      Deprecated.warning("The arguments you're passing to " +
-                         "openInExternalEditor are using an out-of-date API.",
-                         "https://developer.mozilla.org/en-US/Add-ons/" +
-                         "Code_snippets/View_Source_for_XUL_Applications");
       if (Components.utils.isCrossProcessWrapper(aDocument)) {
         throw new Error("View Source cannot accept a CPOW as a document.");
       }


### PR DESCRIPTION
This is a low impact patch. I have tested all the entry points into `View Source` and they still work.

----

Tag #280 