### PR TITLE
Restore source-editor commands controller for scratchpad & styleeditor menus

### DIFF
--- a/devtools/client/scratchpad/scratchpad.js
+++ b/devtools/client/scratchpad/scratchpad.js
@@ -1744,6 +1744,9 @@ var Scratchpad = {
       this.editor.focus();
       this.editor.setCursor({ line: lines.length, ch: lines.pop().length });
 
+      // Add the commands controller for the source-editor.
+      this.editor.insertCommandsController();
+
       if (state)
         this.dirty = !state.saved;
 

--- a/devtools/client/sourceeditor/editor-commands-controller.js
+++ b/devtools/client/sourceeditor/editor-commands-controller.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/**
+ * The source editor exposes XUL commands that can be used when embedded in a XUL
+ * document. This controller drives the availability and behavior of the commands. When
+ * the editor input field is focused, this controller will update the matching menu item
+ * entries found in application menus or context menus.
+ */
+
+/**
+ * Returns a controller object that can be used for editor-specific commands:
+ * - find
+ * - find again
+ * - go to line
+ * - undo
+ * - redo
+ * - delete
+ * - select all
+ */
+function createController(ed) {
+  return {
+    supportsCommand: function (cmd) {
+      switch (cmd) {
+        case "cmd_find":
+        case "cmd_findAgain":
+        case "cmd_gotoLine":
+        case "cmd_undo":
+        case "cmd_redo":
+        case "cmd_delete":
+        case "cmd_selectAll":
+          return true;
+      }
+
+      return false;
+    },
+
+    isCommandEnabled: function (cmd) {
+      let cm = ed.codeMirror;
+
+      switch (cmd) {
+        case "cmd_find":
+        case "cmd_gotoLine":
+        case "cmd_selectAll":
+          return true;
+        case "cmd_findAgain":
+          return cm.state.search != null && cm.state.search.query != null;
+        case "cmd_undo":
+          return ed.canUndo();
+        case "cmd_redo":
+          return ed.canRedo();
+        case "cmd_delete":
+          return ed.somethingSelected();
+      }
+
+      return false;
+    },
+
+    doCommand: function (cmd) {
+      let cm = ed.codeMirror;
+
+      let map = {
+        "cmd_selectAll": "selectAll",
+        "cmd_find": "find",
+        "cmd_undo": "undo",
+        "cmd_redo": "redo",
+        "cmd_delete": "delCharAfter",
+        "cmd_findAgain": "findNext"
+      };
+
+      if (map[cmd]) {
+        cm.execCommand(map[cmd]);
+        return;
+      }
+
+      if (cmd == "cmd_gotoLine") {
+        ed.jumpToLine();
+      }
+    },
+
+    onEvent: function () {}
+  };
+}
+
+/**
+ * Create and insert a commands controller for the provided SourceEditor instance.
+ */
+function insertCommandsController(sourceEditor) {
+  let input = sourceEditor.codeMirror.getInputField();
+  let controller = createController(sourceEditor);
+  input.controllers.insertControllerAt(0, controller);
+}
+
+module.exports = { insertCommandsController };

--- a/devtools/client/sourceeditor/editor.js
+++ b/devtools/client/sourceeditor/editor.js
@@ -495,6 +495,16 @@ Editor.prototype = {
   },
 
   /**
+   * The source editor can expose several commands linked from system and context menus.
+   * Kept for backward compatibility with scratchpad and styleeditor.
+   */
+  insertCommandsController: function () {
+    const { insertCommandsController } =
+      require("devtools/client/sourceeditor/editor-commands-controller");
+    insertCommandsController(this);
+  },
+
+  /**
    * Returns text from the text area. If line argument is provided
    * the method returns only that line.
    */

--- a/devtools/client/sourceeditor/moz.build
+++ b/devtools/client/sourceeditor/moz.build
@@ -12,6 +12,7 @@ DevToolsModules(
     'autocomplete.js',
     'css-autocompleter.js',
     'debugger.js',
+    'editor-commands-controller.js',
     'editor.js'
 )
 

--- a/devtools/client/styleeditor/StyleSheetEditor.jsm
+++ b/devtools/client/styleeditor/StyleSheetEditor.jsm
@@ -468,6 +468,9 @@ StyleSheetEditor.prototype = {
         sourceEditor.container.addEventListener("mousemove", this._onMouseMove);
       }
 
+      // Add the commands controller for the source-editor.
+      sourceEditor.insertCommandsController();
+
       this.emit("source-editor-load");
     });
   },


### PR DESCRIPTION
This resolves #51

---

I've created the new build (x32, Windows) and tested.
