### PR TITLE
Fix "undefined entity" issue on Linux

### DIFF
--- a/application/basilisk/locales/en-US/chrome/browser/migration/migration.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/migration/migration.dtd
@@ -6,6 +6,7 @@
 <!ENTITY migrationWizard.title          "Import Wizard">
 
 <!ENTITY importFrom.label               "Import Preferences, Bookmarks, History, Passwords and other data from:">
+<!ENTITY importFromUnix.label           "Import Preferences, Bookmarks, History, Passwords and other data from:">
 <!ENTITY importFromBookmarks.label      "Import Bookmarks from:">
 
 <!ENTITY importFromIE.label             "Microsoft Internet Explorer">


### PR DESCRIPTION
```
XML Parsing Error: undefined entity
Location: chrome://browser/content/migration/migration.xul
Line Number 24, Column 61:    <description id="importAll" control="importSourceGroup">&importFromUnix.label;</description>
```
Line comes from https://github.com/mozilla/gecko-dev/blob/master/browser/locales/en-US/chrome/browser/migration/migration.dtd#L9