### PR TITLE
Show the Status Line (e.g. "HTTP/2.0 200 OK") in raw headers (response)

### DIFF
--- a/devtools/client/netmonitor/shared/components/headers-panel.js
+++ b/devtools/client/netmonitor/shared/components/headers-panel.js
@@ -176,6 +176,8 @@ const HeadersPanel = createClass({
 
     let summaryVersion = httpVersion ?
       this.renderSummary(SUMMARY_VERSION, httpVersion) : null;
+    // display Status-Line above other response headers
+    let statusLine = `${httpVersion} ${status} ${statusText}\n`;
 
     let summaryRawHeaders;
     if (this.state.rawHeadersOpened) {
@@ -192,7 +194,7 @@ const HeadersPanel = createClass({
             div({ className: "raw-headers" },
               div({ className: "tabpanel-summary-label" }, RAW_HEADERS_RESPONSE),
               textarea({
-                value: writeHeaderText(responseHeaders.headers),
+                value: statusLine + writeHeaderText(responseHeaders.headers),
                 readOnly: true,
               }),
             ),


### PR DESCRIPTION
This resolves https://github.com/MoonchildProductions/Pale-Moon/issues/1602 (you add the label `Devtools`, please)

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1419401

I've created the new build (x32, Windows) and tested.
