### PR TITLE
Set a sandboxName on the WebExtensions Content Script sandboxes

### DIFF
--- a/toolkit/components/extensions/ExtensionContent.jsm
+++ b/toolkit/components/extensions/ExtensionContent.jsm
@@ -355,6 +355,7 @@ class ContentScriptContextChild extends BaseContext {
       // because it enables us to create the APIs object in this sandbox object and then copying it
       // into the iframe's window, see Bug 1214658 for rationale)
       this.sandbox = Cu.Sandbox(contentWindow, {
+        sandboxName: `Web-Accessible Extension Page ${this.extension.id}`,
         sandboxPrototype: contentWindow,
         sameZoneAs: contentWindow,
         wantXrays: false,
@@ -371,6 +372,7 @@ class ContentScriptContextChild extends BaseContext {
 
       this.sandbox = Cu.Sandbox(principal, {
         metadata,
+        sandboxName: `Content Script ${this.extension.id}`,
         sandboxPrototype: contentWindow,
         sameZoneAs: contentWindow,
         wantXrays: true,


### PR DESCRIPTION
This resolves #327

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1410415
(+ https://hg.mozilla.org/mozilla-central/rev/4806f6814163#l1.13)

---

I've created the new build (x32, Windows) and tested.
