### PR TITLE
printconfigsettings.py python errors out because a file doesn't exist.

### DIFF
--- a/config/printconfigsetting.py
+++ b/config/printconfigsetting.py
@@ -4,28 +4,35 @@
 
 import configobj
 import sys
+import os
 import re
 from StringIO import StringIO
+
+script_name = os.path.basename(__file__)
 
 try:
     (file, section, key) = sys.argv[1:]
 except ValueError:
-    print "Usage: printconfigsetting.py <file> <section> <setting>"
+    print "{0}: Usage: printconfigsetting.py <file> <section> <setting>".format(script_name)
     sys.exit(1)
 
-with open(file) as fh:
-    content = re.sub('^\s*;', '#', fh.read(), flags=re.M)
+if os.path.exists(file):
+  with open(file) as fh:
+      content = re.sub('^\s*;', '#', fh.read(), flags=re.M)
+else:
+  print >>sys.stderr, "{0}: warning: File {1} not found.".format(script_name, file)
+  sys.exit(0)
 
 c = configobj.ConfigObj(StringIO(content))
 
 try:
     s = c[section]
 except KeyError:
-    print >>sys.stderr, "Section [%s] not found." % section
+    print >>sys.stderr, "{0}: error: Section [{1}] not found.".format(script_name, section)
     sys.exit(1)
 
 try:
     print s[key]
 except KeyError:
-    print >>sys.stderr, "Key %s not found." % key
+    print >>sys.stderr, "{0}: error: Key {1} not found.".format(script_name, key)
     sys.exit(1)


### PR DESCRIPTION
platform.ini is never there at the beginning of a clean or restart of an incomplete build and this causes one of Mozilla's one off scripts to python crash even though it is not considered fatal to the build system.

This simply checks if file exists and if not exits 0 with a warning message. The Warning and errors are also refined so that one knows where they are coming from when it does its thing.