### PR TITLE
Fix preprocessing in moz.build files after recent patches

### DIFF
--- a/toolkit/components/search/moz.build
+++ b/toolkit/components/search/moz.build
@@ -7,7 +7,6 @@
 XPCSHELL_TESTS_MANIFESTS += ['tests/xpcshell/xpcshell.ini']
 
 EXTRA_COMPONENTS += [
-    'nsSearchService.js',
     'nsSearchSuggestions.js',
 ]
 
@@ -22,8 +21,9 @@ EXTRA_JS_MODULES += [
 ]
 
 EXTRA_PP_COMPONENTS += [
+    'nsSearchService.js',
     'toolkitsearch.manifest',
-]
+  ]
 
 EXTRA_JS_MODULES += [
     'SearchStaticData.jsm',

--- a/toolkit/identity/moz.build
+++ b/toolkit/identity/moz.build
@@ -18,6 +18,7 @@ SOURCES += [
 ]
 
 EXTRA_JS_MODULES.identity += [
+    'FirefoxAccounts.jsm',
     'Identity.jsm',
     'IdentityProvider.jsm',
     'IdentityStore.jsm',
@@ -27,10 +28,6 @@ EXTRA_JS_MODULES.identity += [
     'MinimalIdentity.jsm',
     'RelyingParty.jsm',
     'Sandbox.jsm',
-]
-
-EXTRA_PP_JS_MODULES.identity += [
-    'FirefoxAccounts.jsm',
 ]
 
 FINAL_LIBRARY = 'xul'


### PR DESCRIPTION
`FirefoxAccounts.jsm` no longer should be preprocessed
`nsSearchService.js` **ABSOLUTELY** needs preprocessed