### PR TITLE
Fix "help cmd" and "cmd refresh" in the Developer Toolbar

### DIFF
--- a/devtools/shared/gcli/commands/cmd.js
+++ b/devtools/shared/gcli/commands/cmd.js
@@ -91,7 +91,7 @@ function loadItemsFromMozDir() {
 }
 
 exports.mozDirLoader = function (name) {
-  return loadItemsFromMozDir().then(items => {
+  return loadItemsFromMozDir()().then(items => {
     return { items };
   });
 };
@@ -141,8 +141,6 @@ exports.items = [
       return !prefBranch.prefHasUserValue(PREF_DIR);
     },
     exec: function (args, context) {
-      gcli.load();
-
       let dirName = prefBranch.getComplexValue(PREF_DIR,
                                               Ci.nsISupportsString).data.trim();
       return l10n.lookupFormat("cmdStatus3", [ dirName ]);
@@ -174,8 +172,6 @@ exports.items = [
     exec: function (args, context) {
       supportsString.data = args.directory;
       prefBranch.setComplexValue(PREF_DIR, Ci.nsISupportsString, supportsString);
-
-      gcli.load();
 
       return l10n.lookupFormat("cmdStatus3", [ args.directory ]);
     }

--- a/devtools/shared/gcli/source/lib/gcli/commands/help.js
+++ b/devtools/shared/gcli/source/lib/gcli/commands/help.js
@@ -275,7 +275,7 @@ exports.items = [
           '  <div if="${command.isParent}">\n' +
           '    <p class="gcli-help-header">${l10n.subCommands}:</p>\n' +
           '    <ul class="gcli-help-${subcommands}">\n' +
-          '      <li if="${subcommands.length === 0}">${l10n.subcommandsNone}</li>\n' +
+          '      <li if="${subcommands.length === 0}">${l10n.subCommandsNone}</li>\n' +
           '      <li foreach="subcommand in ${subcommands}">\n' +
           '        ${subcommand.name}: ${subcommand.description}\n' +
           '        <span class="gcli-out-shortcut" data-command="help ${subcommand.name}"\n' +
@@ -321,7 +321,7 @@ exports.items = [
           '\n' +
           '<span if="${command.isParent}"># ${l10n.subCommands}:</span>\n' +
           '\n' +
-          '<span if="${subcommands.length === 0}">${l10n.subcommandsNone}</span>\n' +
+          '<span if="${subcommands.length === 0}">${l10n.subCommandsNone}</span>\n' +
           '<loop foreach="subcommand in ${subcommands}">* ${subcommand.name}: ${subcommand.description}\n' +
           '</loop>\n' +
           '</div>\n',

--- a/devtools/shared/locales/en-US/gcli.properties
+++ b/devtools/shared/locales/en-US/gcli.properties
@@ -141,9 +141,10 @@ helpManual=Provide help either on a specific command (if a search string is prov
 helpSearchDesc=Search string
 helpSearchManual3=search string to use in narrowing down the displayed commands. Regular expressions not supported.
 
-# LOCALIZATION NOTE: These strings are displayed in the help page for a
-# command in the console.
+# LOCALIZATION NOTE (helpManSynopsis, helpManDescription): These strings are
+# displayed in the help page for a command in the console.
 helpManSynopsis=Synopsis
+helpManDescription=Description
 
 # LOCALIZATION NOTE: This message is displayed in the help page if the command
 # has no parameters.
@@ -176,6 +177,10 @@ helpIntro=GCLI is an experiment to create a highly usable command line for web d
 # when the command in question has sub-commands, before a list of the matching
 # sub-commands.
 subCommands=Sub-Commands
+
+# LOCALIZATION NOTE: Text shown as part of the output of the 'help' command
+# when the command in question should have sub-commands but in fact has none.
+subCommandsNone=None
 
 # LOCALIZATION NOTE: This error message is displayed when the command line is
 # cannot find a match for the parse types.


### PR DESCRIPTION
This resolves #347 → You add the label `Devtools`, please

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1419171
https://bugzilla.mozilla.org/show_bug.cgi?id=1359258

---

You add the label `String Changes`, please.

---

I've created the new build (x32, Windows) and tested.
